### PR TITLE
Admin Tools may detect Tomcat installation even when XWiki is running on another server #54

### DIFF
--- a/application-admintools-api/src/main/java/com/xwiki/admintools/ServerInfo.java
+++ b/application-admintools-api/src/main/java/com/xwiki/admintools/ServerInfo.java
@@ -33,13 +33,13 @@ import org.xwiki.component.annotation.Role;
 public interface ServerInfo
 {
     /**
-     * Verify if a specific server is used. If a server path is provided in the XWiki configurations, it verifies if the
-     * path corresponds to a server. Otherwise, it searches the server location in system properties and system
-     * environment.
+     * Verify if the path to a specific server is found. If a server path is provided in the XWiki configurations, it
+     * verifies if the path corresponds to a server. Otherwise, it searches the server location in system properties
+     * and system environment.
      *
      * @return {@code true} if the server is used, {@code false} otherwise.
      */
-    boolean isUsed();
+    boolean foundServerPath();
 
     /**
      * Extract the hint of a component.

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/CurrentServer.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/CurrentServer.java
@@ -31,6 +31,7 @@ import org.xwiki.component.phase.Initializable;
 import org.xwiki.component.phase.InitializationException;
 
 import com.xwiki.admintools.ServerInfo;
+import com.xwiki.admintools.internal.wikiUsage.UsageDataProvider;
 
 /**
  * Manages the server identifiers and offers endpoints to retrieve info about their paths.
@@ -41,8 +42,13 @@ import com.xwiki.admintools.ServerInfo;
 @Singleton
 public class CurrentServer implements Initializable
 {
+    private static final String SERVER_NAME_KEY = "name";
+
     @Inject
     private Provider<List<ServerInfo>> supportedServers;
+
+    @Inject
+    private UsageDataProvider usageDataProvider;
 
     private ServerInfo currentServerInfo;
 
@@ -93,7 +99,9 @@ public class CurrentServer implements Initializable
     {
         this.currentServerInfo = null;
         for (ServerInfo serverInfo : this.supportedServers.get()) {
-            if (serverInfo.isUsed()) {
+            boolean matchingHint = usageDataProvider.getServerMetadata().get(SERVER_NAME_KEY).toLowerCase()
+                .contains(serverInfo.getComponentHint());
+            if (matchingHint && serverInfo.isUsed()) {
                 this.currentServerInfo = serverInfo;
                 this.currentServerInfo.updatePossiblePaths();
                 break;

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/CurrentServer.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/CurrentServer.java
@@ -101,7 +101,7 @@ public class CurrentServer implements Initializable
         for (ServerInfo serverInfo : this.supportedServers.get()) {
             boolean matchingHint = usageDataProvider.getServerMetadata().get(SERVER_NAME_KEY).toLowerCase()
                 .contains(serverInfo.getComponentHint());
-            if (matchingHint && serverInfo.isUsed()) {
+            if (matchingHint && serverInfo.foundServerPath()) {
                 this.currentServerInfo = serverInfo;
                 this.currentServerInfo.updatePossiblePaths();
                 break;

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/TomcatInfo.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/TomcatInfo.java
@@ -42,7 +42,7 @@ public class TomcatInfo extends AbstractServerInfo
     /**
      * Component identifier.
      */
-    public static final String HINT = "Tomcat";
+    public static final String HINT = "tomcat";
 
     @Override
     public boolean isUsed()

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/TomcatInfo.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/identifiers/TomcatInfo.java
@@ -45,7 +45,7 @@ public class TomcatInfo extends AbstractServerInfo
     public static final String HINT = "tomcat";
 
     @Override
-    public boolean isUsed()
+    public boolean foundServerPath()
     {
         this.serverPath = null;
         String providedConfigServerPath = this.adminToolsConfig.getServerPath();

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/CurrentServerTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/CurrentServerTest.java
@@ -21,6 +21,7 @@ package com.xwiki.admintools.internal.data.identifiers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -34,6 +35,7 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xwiki.admintools.ServerInfo;
 import com.xwiki.admintools.configuration.AdminToolsConfiguration;
+import com.xwiki.admintools.internal.wikiUsage.UsageDataProvider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -60,6 +62,9 @@ class CurrentServerTest
     @Named("default")
     private AdminToolsConfiguration adminToolsConfig;
 
+    @MockComponent
+    private UsageDataProvider usageDataProvider;
+
     @BeforeComponent
     void setUp()
     {
@@ -68,6 +73,8 @@ class CurrentServerTest
         mockServerInfos.add(serverInfo);
         when(supportedServers.get()).thenReturn(mockServerInfos);
         when(serverInfo.isUsed()).thenReturn(true);
+        when(usageDataProvider.getServerMetadata()).thenReturn(Map.of("name", "Tomcat Apache"));
+        when(serverInfo.getComponentHint()).thenReturn("tomcat");
 
         // Mock the behavior of adminToolsConfig.
         when(adminToolsConfig.getServerPath()).thenReturn("exampleServerPath");

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/CurrentServerTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/CurrentServerTest.java
@@ -72,7 +72,7 @@ class CurrentServerTest
         List<ServerInfo> mockServerInfos = new ArrayList<>();
         mockServerInfos.add(serverInfo);
         when(supportedServers.get()).thenReturn(mockServerInfos);
-        when(serverInfo.isUsed()).thenReturn(true);
+        when(serverInfo.foundServerPath()).thenReturn(true);
         when(usageDataProvider.getServerMetadata()).thenReturn(Map.of("name", "Tomcat Apache"));
         when(serverInfo.getComponentHint()).thenReturn("tomcat");
 
@@ -93,7 +93,7 @@ class CurrentServerTest
     @Test
     void initializeWithServerNotFound() throws InitializationException
     {
-        when(serverInfo.isUsed()).thenReturn(false);
+        when(serverInfo.foundServerPath()).thenReturn(false);
         currentServer.initialize();
 
         assertNull(currentServer.getCurrentServer());
@@ -102,11 +102,11 @@ class CurrentServerTest
     @Test
     void updateCurrentServer()
     {
-        when(serverInfo.isUsed()).thenReturn(false);
+        when(serverInfo.foundServerPath()).thenReturn(false);
         currentServer.updateCurrentServer();
         assertNull(currentServer.getCurrentServer());
 
-        when(serverInfo.isUsed()).thenReturn(true);
+        when(serverInfo.foundServerPath()).thenReturn(true);
         currentServer.updateCurrentServer();
         assertEquals(serverInfo, currentServer.getCurrentServer());
     }

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/TomcatIdentifierTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/TomcatIdentifierTest.java
@@ -56,7 +56,7 @@ class TomcatIdentifierTest
     private File tmpDir;
 
     @Test
-    void isUsedFound() throws IOException
+    void foundServerPathTrue() throws IOException
     {
         when(adminToolsConfig.getServerPath()).thenReturn(tmpDir.getAbsolutePath());
 
@@ -69,11 +69,11 @@ class TomcatIdentifierTest
         assertTrue(testFile.exists());
 
         // Test with a valid providedConfigServerPath
-        assertTrue(tomcatIdentifier.isUsed());
+        assertTrue(tomcatIdentifier.foundServerPath());
     }
 
     @Test
-    void isUsedWithValidCatalinaBase() throws IOException
+    void foundServerPathWithValidCatalinaBase() throws IOException
     {
         File configDirectory = new File(tmpDir, "conf");
         configDirectory.mkdir();
@@ -85,18 +85,18 @@ class TomcatIdentifierTest
 
         when(adminToolsConfig.getServerPath()).thenReturn(null);
         System.setProperty("catalina.base", tmpDir.getAbsolutePath());
-        assertTrue(tomcatIdentifier.isUsed());
+        assertTrue(tomcatIdentifier.foundServerPath());
         System.clearProperty("catalina.base");
     }
 
     @Test
-    void isUsedValidSystemPathMissingCatalinaProperties()
+    void foundServerPathValidSystemPathMissingCatalinaProperties()
     {
         File configDirectory = new File(tmpDir, "conf");
         configDirectory.mkdir();
         when(adminToolsConfig.getServerPath()).thenReturn(null);
         System.setProperty("catalina.base", tmpDir.getAbsolutePath());
-        assertFalse(tomcatIdentifier.isUsed());
+        assertFalse(tomcatIdentifier.foundServerPath());
         System.clearProperty("catalina.base");
         configDirectory.delete();
     }

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/TomcatIdentifierTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/data/identifiers/TomcatIdentifierTest.java
@@ -104,6 +104,6 @@ class TomcatIdentifierTest
     @Test
     void getIdentifier()
     {
-        assertEquals("Tomcat", tomcatIdentifier.getComponentHint());
+        assertEquals("tomcat", tomcatIdentifier.getComponentHint());
     }
 }


### PR DESCRIPTION
Added an additional check for the server name to avoid incorrect server identifications.