### PR TITLE
Event listener initialization error #84

### DIFF
--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/AdminToolsEventListener.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/AdminToolsEventListener.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.xwiki.bridge.event.DocumentDeletedEvent;
@@ -63,7 +64,7 @@ public class AdminToolsEventListener extends AbstractEventListener
     private WikiDescriptorManager wikiManager;
 
     @Inject
-    private CurrentServer currentServer;
+    private Provider<CurrentServer> currentServer;
 
     /**
      * Creates an event-listener filtering for DocumentUpdatedEvent and DocumentDeletedEvent.
@@ -79,7 +80,7 @@ public class AdminToolsEventListener extends AbstractEventListener
         if (event instanceof DocumentUpdatedEvent || event instanceof DocumentDeletedEvent) {
             XWikiDocument document = (XWikiDocument) source;
             if (document != null && isAdminToolsConfigObject(document)) {
-                this.currentServer.updateCurrentServer();
+                this.currentServer.get().updateCurrentServer();
             }
         }
     }

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/SecurityDataProvider.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/data/SecurityDataProvider.java
@@ -122,8 +122,8 @@ public class SecurityDataProvider extends AbstractDataProvider
         Map<String, String> results = new HashMap<>();
         String workDirectory = System.getenv(WORK_DIRECTORY);
         String language = System.getenv(LANGUAGE);
-        results.put(WORK_DIRECTORY, System.getenv(WORK_DIRECTORY));
-        results.put(LANGUAGE, System.getenv(LANGUAGE));
+        results.put(WORK_DIRECTORY, workDirectory);
+        results.put(LANGUAGE, language);
         if (workDirectory == null || language == null) {
             this.logger.warn("Failed to access language or work directory environment variables.");
         }


### PR DESCRIPTION
Used `javax Provider` to avoid initialization errors for `AdminToolsEventListener`.