### PR TITLE
Replace scrollable instance usage results with live data #86

### DIFF
--- a/application-admintools-api/src/main/java/com/xwiki/admintools/WikiSizeResult.java
+++ b/application-admintools-api/src/main/java/com/xwiki/admintools/WikiSizeResult.java
@@ -19,6 +19,9 @@
  */
 package com.xwiki.admintools;
 
+import java.text.DecimalFormat;
+import java.util.List;
+
 import org.xwiki.stability.Unstable;
 
 /**
@@ -34,7 +37,7 @@ public class WikiSizeResult
 
     private Long userCount;
 
-    private String attachmentsSize;
+    private Long attachmentsSize;
 
     private Long attachmentsCount;
 
@@ -92,7 +95,7 @@ public class WikiSizeResult
      *
      * @return formatted {@link String} with the size of the attachments in the wiki and corresponding size unit.
      */
-    public String getAttachmentsSize()
+    public Long getAttachmentsSize()
     {
         return attachmentsSize;
     }
@@ -102,7 +105,7 @@ public class WikiSizeResult
      *
      * @param attachmentsSize the size of the attachments in the wiki and corresponding size unit.
      */
-    public void setAttachmentsSize(String attachmentsSize)
+    public void setAttachmentsSize(Long attachmentsSize)
     {
         this.attachmentsSize = attachmentsSize;
     }
@@ -145,5 +148,23 @@ public class WikiSizeResult
     public void setDocumentsCount(Long documentsCount)
     {
         this.documentsCount = documentsCount;
+    }
+
+    /**
+     * Get the size of the attachments in a readable format.
+     *
+     * @return a {@link String} with the size of the attachments converted to the corresponding unit of measurement.
+     */
+    public String getReadableAttachmentSize()
+    {
+        if (this.attachmentsSize == null || this.attachmentsSize <= 0) {
+            return "0";
+        }
+        List<String> units = List.of("B", "KB", "MB", "GB");
+        int digitGroup = (int) (Math.log10(this.attachmentsSize) / Math.log10(1024));
+        DecimalFormat decimalFormat = new DecimalFormat("#,##0.#");
+        String resultedSize = decimalFormat.format(this.attachmentsSize / Math.pow(1024, digitGroup));
+
+        return String.format("%s %s", resultedSize, units.get(digitGroup));
     }
 }

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/AdminToolsManager.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/AdminToolsManager.java
@@ -21,6 +21,7 @@ package com.xwiki.admintools.internal;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -34,8 +35,8 @@ import org.xwiki.query.QueryException;
 import org.xwiki.wiki.descriptor.WikiDescriptor;
 import org.xwiki.wiki.manager.WikiManagerException;
 
-import com.xpn.xwiki.XWikiException;
 import com.xwiki.admintools.DataProvider;
+import com.xwiki.admintools.WikiSizeResult;
 import com.xwiki.admintools.health.WikiRecycleBins;
 import com.xwiki.admintools.internal.data.identifiers.CurrentServer;
 import com.xwiki.admintools.internal.files.ImportantFilesManager;
@@ -150,9 +151,8 @@ public class AdminToolsManager
      * @param maxComments maximum number of comments below which the page is ignored.
      * @return a {@link List} with the documents that have more than the given number of comments.
      * @throws QueryException if the query to retrieve the document fails.
-     * @throws XWikiException if a document is not found.
      */
-    public List<String> getPagesOverGivenNumberOfComments(long maxComments) throws QueryException, XWikiException
+    public List<String> getPagesOverGivenNumberOfComments(long maxComments) throws QueryException
     {
         return instanceUsage.getDocumentsOverGivenNumberOfComments(maxComments);
     }
@@ -170,5 +170,18 @@ public class AdminToolsManager
     public List<WikiRecycleBins> getWikisRecycleBinsSize() throws WikiManagerException
     {
         return this.recycleBinsManager.getWikisRecycleBinsSize();
+    }
+
+    /**
+     * Get a {@link List} of {@link WikiSizeResult} with the options to sort it and apply filters on it.
+     *
+     * @param filters {@link Map} of filters to be applied on the gathered list.
+     * @param sortColumn target column to apply the sort on.
+     * @param order the order of the sort.
+     * @return a filtered and sorted {@link List} of {@link WikiSizeResult}.
+     */
+    public List<WikiSizeResult> getWikiSizeResults(Map<String, String> filters, String sortColumn, String order)
+    {
+        return this.instanceUsage.getWikisSize(filters, sortColumn, order);
     }
 }

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsage.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsage.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -132,9 +131,8 @@ public class InstanceUsage
                 return this.templateManager.render(TEMPLATE_NAME);
             }
 
-            String wikiName = this.wikiDescriptorManager.getCurrentWikiDescriptor().getPrettyName();
-            List<WikiSizeResult> currentWikiUsage = getWikisSize(new HashMap<>(Map.of(NAME_KEY, wikiName)), "", "");
-            WikiSizeResult currentWiki = !currentWikiUsage.isEmpty() ? currentWikiUsage.get(0) : null;
+            WikiDescriptor currentWikiDescriptor = this.wikiDescriptorManager.getCurrentWikiDescriptor();
+            WikiSizeResult currentWiki = usageDataProvider.getWikiSize(currentWikiDescriptor);
             scriptContext.setAttribute("currentWikiUsage", currentWiki, ScriptContext.ENGINE_SCOPE);
 
             scriptContext.setAttribute("extensionCount", usageDataProvider.getExtensionCount(),

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsage.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsage.java
@@ -22,7 +22,10 @@ package com.xwiki.admintools.internal.wikiUsage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -59,6 +62,18 @@ public class InstanceUsage
     private static final String TEMPLATE_NAME = "wikiSizeTemplate.vm";
 
     private static final String ERROR_TEMPLATE = "licenseError.vm";
+
+    private static final String NAME_KEY = "name";
+
+    private static final String USER_COUNT_KEY = "userCount";
+
+    private static final String ATTACHMENTS_SIZE_KEY = "attachmentsSize";
+
+    private static final String ATTACHMENTS_COUNT_KEY = "attachmentsCount";
+
+    private static final String DOCUMENTS_COUNT_KEY = "documentsCount";
+
+    private static final String INTERVAL_SEPARATOR = "-";
 
     @Inject
     protected Provider<XWikiContext> xcontextProvider;
@@ -116,12 +131,16 @@ public class InstanceUsage
                 this.logger.error("Used server not found!");
                 return this.templateManager.render(TEMPLATE_NAME);
             }
-            List<WikiSizeResult> instanceUsage = getWikisSize();
-            scriptContext.setAttribute("instanceUsage", instanceUsage, ScriptContext.ENGINE_SCOPE);
-            int extensionCount = usageDataProvider.getExtensionCount();
-            scriptContext.setAttribute("extensionCount", extensionCount, ScriptContext.ENGINE_SCOPE);
-            long totalUsers = usageDataProvider.getInstanceUsersCount();
-            scriptContext.setAttribute("totalUsers", totalUsers, ScriptContext.ENGINE_SCOPE);
+
+            String wikiName = this.wikiDescriptorManager.getCurrentWikiDescriptor().getPrettyName();
+            List<WikiSizeResult> currentWikiUsage = getWikisSize(new HashMap<>(Map.of(NAME_KEY, wikiName)), "", "");
+            WikiSizeResult currentWiki = !currentWikiUsage.isEmpty() ? currentWikiUsage.get(0) : null;
+            scriptContext.setAttribute("currentWikiUsage", currentWiki, ScriptContext.ENGINE_SCOPE);
+
+            scriptContext.setAttribute("extensionCount", usageDataProvider.getExtensionCount(),
+                ScriptContext.ENGINE_SCOPE);
+            scriptContext.setAttribute("totalUsers", usageDataProvider.getInstanceUsersCount(),
+                ScriptContext.ENGINE_SCOPE);
             return this.templateManager.render(TEMPLATE_NAME);
         } catch (Exception e) {
             this.logger.warn("Failed to render [{}] template. Root cause is: [{}]", TEMPLATE_NAME,
@@ -145,19 +164,92 @@ public class InstanceUsage
             .setWiki(wikiDescriptorManager.getCurrentWikiId()).bindValue("maxComments", maxComments).execute();
     }
 
-    private List<WikiSizeResult> getWikisSize()
+    /**
+     * Get a {@link List} of {@link WikiSizeResult} with the options to sort it and apply filters on it.
+     *
+     * @param filters {@link Map} of filters to be applied on the gathered list.
+     * @param sortColumn target column to apply the sort on.
+     * @param order the order of the sort.
+     * @return a filtered and sorted {@link List} of {@link WikiSizeResult}.
+     */
+    public List<WikiSizeResult> getWikisSize(Map<String, String> filters, String sortColumn, String order)
     {
         List<WikiSizeResult> result = new ArrayList<>();
         try {
             Collection<WikiDescriptor> wikisDescriptors = this.wikiDescriptorManager.getAll();
-            for (WikiDescriptor wikiDescriptor : wikisDescriptors) {
-                result.add(usageDataProvider.getWikiSize(wikiDescriptor));
+            String filteredName = filters.get(NAME_KEY);
+            if (filteredName != null && !filteredName.isEmpty()) {
+                wikisDescriptors.removeIf(
+                    wiki -> !wiki.getPrettyName().toLowerCase().contains(filteredName.toLowerCase()));
+                filters.remove(NAME_KEY);
             }
+
+            for (WikiDescriptor wikiDescriptor : wikisDescriptors) {
+                WikiSizeResult wikiSizeResult = usageDataProvider.getWikiSize(wikiDescriptor);
+                if (checkFilters(filters, wikiSizeResult)) {
+                    result.add(wikiSizeResult);
+                }
+            }
+            applySort(result, sortColumn, order);
             return result;
         } catch (Exception e) {
             logger.warn("There have been issues while gathering instance usage data. Root cause is: [{}]",
                 ExceptionUtils.getRootCauseMessage(e));
             return new ArrayList<>();
+        }
+    }
+
+    private boolean checkFilters(Map<String, String> filters, WikiSizeResult wikiData)
+    {
+        return filters.entrySet().stream().filter(
+            filter -> filter.getValue() != null && !filter.getValue().isEmpty() && !filter.getValue()
+                .equals(INTERVAL_SEPARATOR)).allMatch(filter -> {
+                    switch (filter.getKey()) {
+                        case USER_COUNT_KEY:
+                            return wikiData.getUserCount().equals(Long.parseLong(filter.getValue()));
+                        case ATTACHMENTS_SIZE_KEY:
+                            String[] interval = filter.getValue().split(INTERVAL_SEPARATOR);
+                            long attachmentsSize = wikiData.getAttachmentsSize();
+                            long lowerBound = Long.parseLong(interval[0]);
+                            long upperBound = "x".equals(interval[1]) ? Long.MAX_VALUE : Long.parseLong(interval[1]);
+                            return attachmentsSize > lowerBound && attachmentsSize < upperBound;
+                        case ATTACHMENTS_COUNT_KEY:
+                            return wikiData.getAttachmentsCount().equals(Long.parseLong(filter.getValue()));
+                        case DOCUMENTS_COUNT_KEY:
+                            return wikiData.getDocumentsCount().equals(Long.parseLong(filter.getValue()));
+                        default:
+                            throw new IllegalArgumentException("Invalid filter field: " + filter.getKey());
+                    }
+                });
+    }
+
+    private void applySort(List<WikiSizeResult> list, String sort, String order)
+    {
+        Comparator<WikiSizeResult> comparator = null;
+        switch (sort) {
+            case NAME_KEY:
+                comparator = Comparator.comparing(WikiSizeResult::getName);
+                break;
+            case USER_COUNT_KEY:
+                comparator = Comparator.comparing(WikiSizeResult::getUserCount);
+                break;
+            case ATTACHMENTS_SIZE_KEY:
+                comparator = Comparator.comparing(WikiSizeResult::getAttachmentsSize);
+                break;
+            case ATTACHMENTS_COUNT_KEY:
+                comparator = Comparator.comparing(WikiSizeResult::getAttachmentsCount);
+                break;
+            case DOCUMENTS_COUNT_KEY:
+                comparator = Comparator.comparing(WikiSizeResult::getDocumentsCount);
+                break;
+            default:
+                break;
+        }
+        if (comparator != null) {
+            if ("desc".equals(order)) {
+                comparator = comparator.reversed();
+            }
+            list.sort(comparator);
         }
     }
 }

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/wikiUsage/UsageDataProvider.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/wikiUsage/UsageDataProvider.java
@@ -19,7 +19,6 @@
  */
 package com.xwiki.admintools.internal.wikiUsage;
 
-import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,7 +147,7 @@ public class UsageDataProvider
         wikiData.setUserCount(getWikiUserCount(wikiId));
         wikiData.setDocumentsCount(getWikiDocumentsCount(wikiId));
         wikiData.setAttachmentsCount(getWikiAttachmentsCount(wikiId));
-        wikiData.setAttachmentsSize(readableSize(getWikiAttachmentSize(wikiId)));
+        wikiData.setAttachmentsSize(getWikiAttachmentSize(wikiId));
 
         return wikiData;
     }
@@ -174,30 +173,17 @@ public class UsageDataProvider
 
     private Long getWikiAttachmentSize(String wikiId) throws QueryException
     {
-        List<Long> results = this.queryManager.createQuery(
-            "select sum(attach.longSize) from XWikiAttachment attach",
-            Query.XWQL).setWiki(wikiId).execute();
+        List<Long> results =
+            this.queryManager.createQuery("select sum(attach.longSize) from XWikiAttachment attach", Query.XWQL)
+                .setWiki(wikiId).execute();
         return results.get(0);
     }
 
     private Long getWikiAttachmentsCount(String wikiId) throws QueryException
     {
-        List<Long> results = this.queryManager.createQuery(
-            "select count(attach) from XWikiAttachment attach",
-            Query.XWQL).setWiki(wikiId).execute();
+        List<Long> results =
+            this.queryManager.createQuery("select count(attach) from XWikiAttachment attach", Query.XWQL)
+                .setWiki(wikiId).execute();
         return results.get(0);
-    }
-
-    private String readableSize(Long number)
-    {
-        if (number == null || number <= 0) {
-            return "0";
-        }
-        List<String> units = List.of("B", "KB", "MB", "GB");
-
-        int digitGroup = (int) (Math.log10(number) / Math.log10(1024));
-        DecimalFormat decimalFormat = new DecimalFormat("#,##0.#");
-        String resultedSize = decimalFormat.format(number / Math.pow(1024, digitGroup));
-        return String.format("%s %s", resultedSize, units.get(digitGroup));
     }
 }

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/script/AdminToolsScriptService.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/script/AdminToolsScriptService.java
@@ -98,7 +98,7 @@ public class AdminToolsScriptService implements ScriptService
      * @param sortColumn target column to apply the sort on.
      * @param order the order of the sort.
      * @return a filtered and sorted {@link List} of {@link WikiSizeResult}.
-     * @throws AccessDeniedException
+     * @throws AccessDeniedException if the requesting user lacks admin rights.
      */
     public List<WikiSizeResult> getWikisSize(Map<String, String> filters, String sortColumn, String order)
         throws AccessDeniedException

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/script/AdminToolsScriptService.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/script/AdminToolsScriptService.java
@@ -20,6 +20,7 @@
 package com.xwiki.admintools.script;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -39,7 +40,7 @@ import org.xwiki.security.authorization.Right;
 import org.xwiki.stability.Unstable;
 import org.xwiki.wiki.manager.WikiManagerException;
 
-import com.xpn.xwiki.XWikiException;
+import com.xwiki.admintools.WikiSizeResult;
 import com.xwiki.admintools.configuration.AdminToolsConfiguration;
 import com.xwiki.admintools.health.WikiRecycleBins;
 import com.xwiki.admintools.internal.AdminToolsManager;
@@ -88,6 +89,22 @@ public class AdminToolsScriptService implements ScriptService
     {
         this.contextualAuthorizationManager.checkAccess(Right.ADMIN);
         return this.adminToolsManager.generateData();
+    }
+
+    /**
+     * Get a {@link List} of {@link WikiSizeResult} with the options to sort it and apply filters on it.
+     *
+     * @param filters {@link Map} of filters to be applied on the gathered list.
+     * @param sortColumn target column to apply the sort on.
+     * @param order the order of the sort.
+     * @return a filtered and sorted {@link List} of {@link WikiSizeResult}.
+     * @throws AccessDeniedException
+     */
+    public List<WikiSizeResult> getWikisSize(Map<String, String> filters, String sortColumn, String order)
+        throws AccessDeniedException
+    {
+        this.contextualAuthorizationManager.checkAccess(Right.ADMIN);
+        return this.adminToolsManager.getWikiSizeResults(filters, sortColumn, order);
     }
 
     /**
@@ -153,8 +170,7 @@ public class AdminToolsScriptService implements ScriptService
      * @return a {@link List} with the documents that have more than the given number of comments, or null if there are
      *     any errors.
      */
-    public List<String> getPagesOverGivenNumberOfComments(long maxComments)
-        throws AccessDeniedException, QueryException, XWikiException
+    public List<String> getPagesOverGivenNumberOfComments(long maxComments) throws AccessDeniedException, QueryException
     {
         this.contextualAuthorizationManager.checkAccess(Right.ADMIN);
         return adminToolsManager.getPagesOverGivenNumberOfComments(maxComments);

--- a/application-admintools-default/src/main/resources/templates/wikiSizeTemplate.vm
+++ b/application-admintools-default/src/main/resources/templates/wikiSizeTemplate.vm
@@ -26,23 +26,19 @@
       [$extensionCount]))</p>
     <p>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.total.users',
       [$totalUsers]))</p>
-    #if ($currentWikiUsage)
-      #set($wikiName = "<strong>$currentWikiUsage.getName()</strong>")
-      $escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.name', [
-        '__WIKINAME__'])).replace('__WIKINAME__', $wikiName)
-      <ul>
-        <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.users', [
-          $currentWikiUsage.getUserCount()]))</li>
-        <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.documents',
-          [$currentWikiUsage.getDocumentsCount()]))</li>
-        <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.attachments',
-          [$currentWikiUsage.getAttachmentsCount(), $currentWikiUsage.getReadableAttachmentSize()]))</li>
-      </ul>
-      <a href="#viewWikisSizeModal" data-toggle="modal" data-target="#viewWikisSizeModal">
-        $escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.viewAll'))</a>
-    #else
-      #error($escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.error')))
-    #end
+    #set($wikiName = "<strong>$currentWikiUsage.getName()</strong>")
+    $escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.name', [
+      '__WIKINAME__'])).replace('__WIKINAME__', $wikiName)
+    <ul>
+      <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.users', [
+        $currentWikiUsage.getUserCount()]))</li>
+      <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.documents',
+        [$currentWikiUsage.getDocumentsCount()]))</li>
+      <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.attachments',
+        [$currentWikiUsage.getAttachmentsCount(), $currentWikiUsage.getReadableAttachmentSize()]))</li>
+    </ul>
+    <a href="#viewWikisSizeModal" data-toggle="modal" data-target="#viewWikisSizeModal">
+      $escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.viewAll'))</a>
     <hr/>
     <div class="specific-stats">
       #set ($spamLimit = $services.admintools.getMinimumSpamSize())

--- a/application-admintools-default/src/main/resources/templates/wikiSizeTemplate.vm
+++ b/application-admintools-default/src/main/resources/templates/wikiSizeTemplate.vm
@@ -26,27 +26,23 @@
       [$extensionCount]))</p>
     <p>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.total.users',
       [$totalUsers]))</p>
-    <div class="wikis-size-info-list">
-      #if ($instanceUsage.size() != 0)
-        <ul>
-          #foreach($wikiData in $instanceUsage)
-            #set($wikiName = "<strong>$wikiData.getName()</strong>")
-            <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.name', [
-              '__WIKINAME__'])).replace('__WIKINAME__', $wikiName)</li>
-            <ul>
-              <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.users', [
-                $wikiData.getUserCount()]))</li>
-              <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.documents',
-                [$wikiData.getDocumentsCount()]))</li>
-              <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.attachments',
-                [$wikiData.getAttachmentsCount(), $wikiData.getAttachmentsSize()]))</li>
-            </ul>
-          #end
-        </ul>
-      #else
-        #error($escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.error')))
-      #end
-    </div>
+    #if ($currentWikiUsage)
+      #set($wikiName = "<strong>$currentWikiUsage.getName()</strong>")
+      $escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.name', [
+        '__WIKINAME__'])).replace('__WIKINAME__', $wikiName)
+      <ul>
+        <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.users', [
+          $currentWikiUsage.getUserCount()]))</li>
+        <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.documents',
+          [$currentWikiUsage.getDocumentsCount()]))</li>
+        <li>$escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.attachments',
+          [$currentWikiUsage.getAttachmentsCount(), $currentWikiUsage.getReadableAttachmentSize()]))</li>
+      </ul>
+      <a href="#viewWikisSizeModal" data-toggle="modal" data-target="#viewWikisSizeModal">
+        $escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.wiki.viewAll'))</a>
+    #else
+      #error($escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.error')))
+    #end
     <hr/>
     <div class="specific-stats">
       #set ($spamLimit = $services.admintools.getMinimumSpamSize())
@@ -66,6 +62,7 @@
     </div>
     #pagesOverNumberOfCommentsModal($spamLimit)
     #recycleBinsModal()
+    #wikisSizeModal()
   </div>
 #else
   #set($warningMessage = $escapetool.xml($services.localization.render('adminTools.dashboard.serverNotFound.error',

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsageTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsageTest.java
@@ -57,6 +57,7 @@ import com.xwiki.licensing.Licensor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -173,14 +174,15 @@ class InstanceUsageTest
     {
         when(wikiDescriptor.getPrettyName()).thenReturn("wiki name");
 
-        when(wikiDescriptorManager.getAll()).thenThrow(new WikiManagerException("Failed to get wiki descriptors."));
-        when(templateManager.render(TEMPLATE_NAME)).thenReturn("fail");
-        assertEquals("fail", instanceUsage.renderTemplate());
+        when(wikiDescriptorManager.getCurrentWikiDescriptor()).thenThrow(
+            new WikiManagerException("Failed to get wiki descriptors."));
+
+        assertNull(this.instanceUsage.renderTemplate());
         verify(scriptContext).setAttribute("found", true, ScriptContext.ENGINE_SCOPE);
-        verify(scriptContext).setAttribute("currentWikiUsage", null, ScriptContext.ENGINE_SCOPE);
-        verify(scriptContext).setAttribute("extensionCount", 2, ScriptContext.ENGINE_SCOPE);
-        verify(scriptContext).setAttribute("totalUsers", 400L, ScriptContext.ENGINE_SCOPE);
-        assertEquals("There have been issues while gathering instance usage data. Root cause is: "
+        verify(scriptContext, never()).setAttribute("currentWikiUsage", null, ScriptContext.ENGINE_SCOPE);
+        verify(scriptContext, never()).setAttribute("extensionCount", 2, ScriptContext.ENGINE_SCOPE);
+        verify(scriptContext, never()).setAttribute("totalUsers", 400L, ScriptContext.ENGINE_SCOPE);
+        assertEquals("Failed to render [wikiSizeTemplate.vm] template. Root cause is: "
             + "[WikiManagerException: Failed to get wiki descriptors.]", logCapture.getMessage(0));
     }
 

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsageTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/wikiUsage/InstanceUsageTest.java
@@ -19,8 +19,11 @@
  */
 package com.xwiki.admintools.internal.wikiUsage;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Provider;
 import javax.script.ScriptContext;
@@ -54,8 +57,6 @@ import com.xwiki.licensing.Licensor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -92,10 +93,16 @@ class InstanceUsageTest
     private WikiDescriptor wikiDescriptor;
 
     @Mock
+    private WikiDescriptor wikiDescriptor2;
+
+    @Mock
     private ScriptContext scriptContext;
 
     @Mock
     private WikiSizeResult wikiSizeResult;
+
+    @Mock
+    private WikiSizeResult wikiSizeResult2;
 
     @MockComponent
     private QueryManager queryManager;
@@ -119,7 +126,7 @@ class InstanceUsageTest
         new DocumentReference("wiki_id", Arrays.asList("AdminTools", "Code"), "ConfigurationClass");
 
     @BeforeEach
-    void setUp()
+    void setUp() throws QueryException, WikiManagerException
     {
         when(xcontextProvider.get()).thenReturn(xWikiContext);
         when(xWikiContext.getWikiId()).thenReturn("wiki_id");
@@ -128,6 +135,9 @@ class InstanceUsageTest
 
         when(currentServer.getCurrentServer()).thenReturn(serverInfo);
         when(scriptContextManager.getScriptContext()).thenReturn(scriptContext);
+        when(usageDataProvider.getWikiSize(wikiDescriptor)).thenReturn(wikiSizeResult);
+        when(wikiDescriptorManager.getCurrentWikiDescriptor()).thenReturn(wikiDescriptor);
+        when(wikiDescriptorManager.getAll()).thenReturn(new ArrayList<>(List.of(wikiDescriptor)));
 
         when(usageDataProvider.getExtensionCount()).thenReturn(2);
         when(usageDataProvider.getInstanceUsersCount()).thenReturn(400L);
@@ -136,14 +146,13 @@ class InstanceUsageTest
     @Test
     void renderTemplate() throws Exception
     {
-        when(wikiDescriptorManager.getAll()).thenReturn(List.of(wikiDescriptor));
-        when(usageDataProvider.getWikiSize(wikiDescriptor)).thenReturn(wikiSizeResult);
+        when(wikiDescriptor.getPrettyName()).thenReturn("wiki name");
 
         when(templateManager.render(TEMPLATE_NAME)).thenReturn("success");
 
         assertEquals("success", instanceUsage.renderTemplate());
         verify(scriptContext).setAttribute("found", true, ScriptContext.ENGINE_SCOPE);
-        verify(scriptContext).setAttribute(eq("instanceUsage"), anyList(), eq(ScriptContext.ENGINE_SCOPE));
+        verify(scriptContext).setAttribute("currentWikiUsage", wikiSizeResult, ScriptContext.ENGINE_SCOPE);
         verify(scriptContext).setAttribute("extensionCount", 2, ScriptContext.ENGINE_SCOPE);
         verify(scriptContext).setAttribute("totalUsers", 400L, ScriptContext.ENGINE_SCOPE);
         assertEquals(0, logCapture.size());
@@ -162,11 +171,13 @@ class InstanceUsageTest
     @Test
     void renderTemplateGetWikisSizeInfoError() throws Exception
     {
+        when(wikiDescriptor.getPrettyName()).thenReturn("wiki name");
+
         when(wikiDescriptorManager.getAll()).thenThrow(new WikiManagerException("Failed to get wiki descriptors."));
         when(templateManager.render(TEMPLATE_NAME)).thenReturn("fail");
         assertEquals("fail", instanceUsage.renderTemplate());
         verify(scriptContext).setAttribute("found", true, ScriptContext.ENGINE_SCOPE);
-        verify(scriptContext).setAttribute(eq("instanceUsage"), anyList(), eq(ScriptContext.ENGINE_SCOPE));
+        verify(scriptContext).setAttribute("currentWikiUsage", null, ScriptContext.ENGINE_SCOPE);
         verify(scriptContext).setAttribute("extensionCount", 2, ScriptContext.ENGINE_SCOPE);
         verify(scriptContext).setAttribute("totalUsers", 400L, ScriptContext.ENGINE_SCOPE);
         assertEquals("There have been issues while gathering instance usage data. Root cause is: "
@@ -176,13 +187,13 @@ class InstanceUsageTest
     @Test
     void renderTemplateError() throws Exception
     {
-        when(wikiDescriptorManager.getAll()).thenReturn(List.of(wikiDescriptor));
+        when(wikiDescriptor.getPrettyName()).thenReturn("wiki name");
 
         when(templateManager.render(TEMPLATE_NAME)).thenThrow(new Exception("Failed to render template."));
 
         assertNull(instanceUsage.renderTemplate());
         verify(scriptContext).setAttribute("found", true, ScriptContext.ENGINE_SCOPE);
-        verify(scriptContext).setAttribute(eq("instanceUsage"), anyList(), eq(ScriptContext.ENGINE_SCOPE));
+        verify(scriptContext).setAttribute("currentWikiUsage", wikiSizeResult, ScriptContext.ENGINE_SCOPE);
         verify(scriptContext).setAttribute("extensionCount", 2, ScriptContext.ENGINE_SCOPE);
         verify(scriptContext).setAttribute("totalUsers", 400L, ScriptContext.ENGINE_SCOPE);
         assertEquals(
@@ -221,5 +232,61 @@ class InstanceUsageTest
         when(licensor.hasLicensure(mainRef)).thenReturn(false);
         when(templateManager.render("licenseError.vm")).thenReturn("invalid license");
         assertEquals("invalid license", instanceUsage.renderTemplate());
+    }
+
+    @Test
+    void checkFilters() throws WikiManagerException, QueryException
+    {
+        when(wikiDescriptorManager.getAll()).thenReturn(new ArrayList<>(List.of(wikiDescriptor, wikiDescriptor2)));
+        when(wikiDescriptor2.getPrettyName()).thenReturn("wiki2 name");
+        when(wikiSizeResult.getAttachmentsCount()).thenReturn(12345L);
+        when(wikiSizeResult.getName()).thenReturn("wiki name");
+        when(wikiSizeResult.getDocumentsCount()).thenReturn(123L);
+        when(wikiSizeResult.getUserCount()).thenReturn(12L);
+        when(wikiSizeResult.getAttachmentsSize()).thenReturn(123456L);
+
+        when(wikiSizeResult2.getAttachmentsCount()).thenReturn(1234L);
+        when(wikiSizeResult2.getName()).thenReturn("wiki2 name");
+        when(wikiSizeResult2.getDocumentsCount()).thenReturn(12L);
+        when(wikiSizeResult2.getUserCount()).thenReturn(1L);
+        when(wikiSizeResult2.getAttachmentsSize()).thenReturn(12345L);
+
+        when(usageDataProvider.getWikiSize(wikiDescriptor)).thenReturn(wikiSizeResult);
+        when(usageDataProvider.getWikiSize(wikiDescriptor2)).thenReturn(wikiSizeResult2);
+
+        Map<String, String> filters = new HashMap<>(
+            Map.of("userCount", "12", "attachmentsSize", "1234-1234567", "attachmentsCount", "12345", "documentsCount",
+                "123"));
+        List<WikiSizeResult> testResults = instanceUsage.getWikisSize(filters, "", "");
+        assertEquals(1, testResults.size());
+        assertEquals("wiki name", testResults.get(0).getName());
+    }
+
+    @Test
+    void checkSort() throws WikiManagerException, QueryException
+    {
+        when(wikiDescriptorManager.getAll()).thenReturn(new ArrayList<>(List.of(wikiDescriptor, wikiDescriptor2)));
+        when(wikiDescriptor2.getPrettyName()).thenReturn("wiki2 name");
+        when(wikiSizeResult.getAttachmentsCount()).thenReturn(12345L);
+        when(wikiSizeResult.getName()).thenReturn("wiki name");
+        when(wikiSizeResult.getDocumentsCount()).thenReturn(123L);
+        when(wikiSizeResult.getUserCount()).thenReturn(12L);
+        when(wikiSizeResult.getAttachmentsSize()).thenReturn(123456L);
+
+        when(wikiSizeResult2.getAttachmentsCount()).thenReturn(1234L);
+        when(wikiSizeResult2.getName()).thenReturn("wiki2 name");
+        when(wikiSizeResult2.getDocumentsCount()).thenReturn(12L);
+        when(wikiSizeResult2.getUserCount()).thenReturn(1L);
+        when(wikiSizeResult2.getAttachmentsSize()).thenReturn(1234567L);
+
+        when(usageDataProvider.getWikiSize(wikiDescriptor)).thenReturn(wikiSizeResult);
+        when(usageDataProvider.getWikiSize(wikiDescriptor2)).thenReturn(wikiSizeResult2);
+
+        Map<String, String> filters =
+            new HashMap<>(Map.of("userCount", "", "attachmentsSize", "", "attachmentsCount", "", "documentsCount", ""));
+        List<WikiSizeResult> testResults = instanceUsage.getWikisSize(filters, "attachmentsSize", "desc");
+        assertEquals(2, testResults.size());
+        assertEquals("wiki2 name", testResults.get(0).getName());
+        assertEquals("wiki name", testResults.get(1).getName());
     }
 }

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/wikiUsage/UsageDataProviderTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/wikiUsage/UsageDataProviderTest.java
@@ -98,15 +98,13 @@ class UsageDataProviderTest
         when(docQuery.addFilter(countFilter)).thenReturn(docQuery);
         when(docQuery.execute()).thenReturn(List.of(12345L));
 
-        when(queryManager.createQuery(
-            "select sum(attach.longSize) from XWikiAttachment attach",
-            "xwql")).thenReturn(attSizeQuery);
+        when(queryManager.createQuery("select sum(attach.longSize) from XWikiAttachment attach", "xwql")).thenReturn(
+            attSizeQuery);
         when(attSizeQuery.setWiki(WIKI_ID)).thenReturn(attSizeQuery);
         when(attSizeQuery.execute()).thenReturn(List.of(123456789L));
 
-        when(queryManager.createQuery(
-            "select count(attach) from XWikiAttachment attach",
-            "xwql")).thenReturn(attCountQuery);
+        when(queryManager.createQuery("select count(attach) from XWikiAttachment attach", "xwql")).thenReturn(
+            attCountQuery);
         when(attCountQuery.setWiki(WIKI_ID)).thenReturn(attCountQuery);
         when(attCountQuery.execute()).thenReturn(List.of(123456L));
 
@@ -117,7 +115,7 @@ class UsageDataProviderTest
         assertEquals(1234L, wiki.getUserCount());
         assertEquals(12345L, wiki.getDocumentsCount());
         assertEquals(123456L, wiki.getAttachmentsCount());
-        assertEquals("117.7 MB", wiki.getAttachmentsSize());
+        assertEquals("117.7 MB", wiki.getReadableAttachmentSize());
     }
 
     @Test

--- a/application-admintools-ui/pom.xml
+++ b/application-admintools-ui/pom.xml
@@ -97,6 +97,7 @@
           <contentPages>
             <contentPage>.*/AdminTools/WebHome\.xml</contentPage>
             <contentPage>.*/AdminTools/HelpLinks\.xml</contentPage>
+            <contentPage>.*/AdminTools/WikisSize\.xml</contentPage>
           </contentPages>
         </configuration>
       </plugin>

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Macros.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Macros.xml
@@ -159,42 +159,40 @@
       aria-labelledby="pagesOverNumberOfCommentsLabel"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
-        &lt;div class="cache-modal-content"&gt;
-          &lt;div class="modal-header"&gt;
-            &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
-              &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
-            &lt;div id="pagesOverNumberOfCommentsLabel" class="modal-title"&gt;
-              $escapetool.xml($services.localization.render('adminTools.dashboard.spamPage.modal.title',
-              [$maxComments]))&lt;/div&gt;
-          &lt;/div&gt;
-          &lt;div class="modal-body"&gt;
-            #set ($spamPages = $services.admintools.getPagesOverGivenNumberOfComments($maxComments))
-            #if ($spamPages.size() != 0)
-              &lt;table id="adminTools_spamPages" class="sortable doOddEven centered"&gt;
-                &lt;tr class="sortHeader"&gt;
-                  &lt;th&gt;$escapetool.xml($services.localization.render(
-                    'adminTools.dashboard.spamPage.modal.header.page'))&lt;/th&gt;
-                  &lt;th&gt;$escapetool.xml($services.localization.render(
-                    'adminTools.dashboard.spamPage.modal.header.noComments'))&lt;/th&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+            &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
+          &lt;div id="pagesOverNumberOfCommentsLabel" class="modal-title"&gt;
+            $escapetool.xml($services.localization.render('adminTools.dashboard.spamPage.modal.title',
+            [$maxComments]))&lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+          #set ($spamPages = $services.admintools.getPagesOverGivenNumberOfComments($maxComments))
+          #if ($spamPages.size() != 0)
+            &lt;table id="adminTools_spamPages" class="sortable doOddEven centered"&gt;
+              &lt;tr class="sortHeader"&gt;
+                &lt;th&gt;$escapetool.xml($services.localization.render(
+                  'adminTools.dashboard.spamPage.modal.header.page'))&lt;/th&gt;
+                &lt;th&gt;$escapetool.xml($services.localization.render(
+                  'adminTools.dashboard.spamPage.modal.header.noComments'))&lt;/th&gt;
+              &lt;/tr&gt;
+              #foreach ($spammedPageReference in $spamPages)
+                #set ($spamPage = $xwiki.getDocument($spammedPageReference))
+                &lt;tr&gt;
+                  &lt;td&gt;&lt;a href='$xwiki.getURL($spamPage.getDocumentReference())'&gt;$spamPage.getTitle()&lt;/a&gt;&lt;/td&gt;
+                  &lt;td&gt;$spamPage.getComments().size()&lt;/td&gt;
                 &lt;/tr&gt;
-                #foreach ($spammedPageReference in $spamPages)
-                  #set ($spamPage = $xwiki.getDocument($spammedPageReference))
-                  &lt;tr&gt;
-                    &lt;td&gt;&lt;a href='$xwiki.getURL($spamPage.getDocumentReference())'&gt;$spamPage.getTitle()&lt;/a&gt;&lt;/td&gt;
-                    &lt;td&gt;$spamPage.getComments().size()&lt;/td&gt;
-                  &lt;/tr&gt;
-                #end
-              &lt;/table&gt;
-            #else
-              #set ($infoMessage = $escapetool.xml(
-                $services.localization.render('adminTools.dashboard.spamPage.modal.notFound', [$maxComments])))
-              #info ($infoMessage)
-            #end
-          &lt;/div&gt;
-          &lt;div class="modal-footer"&gt;
-            &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
-              $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
-          &lt;/div&gt;
+              #end
+            &lt;/table&gt;
+          #else
+            #set ($infoMessage = $escapetool.xml(
+              $services.localization.render('adminTools.dashboard.spamPage.modal.notFound', [$maxComments])))
+            #info ($infoMessage)
+          #end
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
         &lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;
@@ -229,65 +227,86 @@
     &lt;/div&gt;
   &lt;/div&gt;
 #end
+#macro (wikisSizeModal)
+  &lt;div class="modal fade" id="viewWikisSizeModal" tabindex="-1" role="dialog"
+      aria-labelledby="viewWikisSizeModalLabel"&gt;
+    &lt;div class="modal-dialog modal-lg" role="document"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+            &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
+          &lt;div id="viewWikisSizeModalLabel" class="modal-title"&gt;
+            $escapetool.xml($services.localization.render('adminTools.dashboard.instanceUsage.modal.wikiSize.title'))
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+          {{include reference="AdminTools.Code.WikisSize" /}}
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+#end
 #macro (recycleBinsModal)
   #set ($discard = $xwiki.jsfx.use('js/xwiki/table/tablefilterNsort.js', true))
   &lt;div class="modal fade" id="checkRecycleBinsModal" tabindex="-1" role="dialog"
       aria-labelledby="checkRecycleBinsModalLabel"&gt;
     &lt;div class="modal-dialog modal-lg" role="document"&gt;
       &lt;div class="modal-content"&gt;
-        &lt;div class="cache-modal-content"&gt;
-          &lt;div class="modal-header"&gt;
-            &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
-              &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
-            &lt;div id="checkRecycleBinsModalLabel" class="modal-title"&gt;
-              $escapetool.xml($services.localization.render('adminTools.dashboard.healthcheck.modal.wikiBins.title'))
-            &lt;/div&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+            &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
+          &lt;div id="checkRecycleBinsModalLabel" class="modal-title"&gt;
+            $escapetool.xml($services.localization.render('adminTools.dashboard.healthcheck.modal.wikiBins.title'))
           &lt;/div&gt;
-          &lt;div class="modal-body"&gt;
-            #set($wikisRecycleBin = $services.admintools.getWikisRecycleBinSize())
-            #if ($wikisRecycleBin != $null)
-              &lt;table id="wikisBins" class="sortable doOddEven centered"&gt;
-                &lt;tr class="sortHeader"&gt;
-                  &lt;th&gt;$escapetool.xml($services.localization.render(
-                    'adminTools.dashboard.healthcheck.modal.wikiBins.header.wiki'))&lt;/th&gt;
-                  &lt;th&gt;$escapetool.xml($services.localization.render(
-                    'adminTools.dashboard.healthcheck.modal.wikiBins.header.page'))&lt;/th&gt;
-                  &lt;th&gt;$escapetool.xml($services.localization.render(
-                    'adminTools.dashboard.healthcheck.modal.wikiBins.header.attach'))&lt;/th&gt;
-                  &lt;th&gt;$escapetool.xml($services.localization.render(
-                    'adminTools.dashboard.healthcheck.modal.wikiBins.header.total'))&lt;/th&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+          #set($wikisRecycleBin = $services.admintools.getWikisRecycleBinSize())
+          #if ($wikisRecycleBin != $null)
+            &lt;table id="wikisBins" class="sortable doOddEven centered"&gt;
+              &lt;tr class="sortHeader"&gt;
+                &lt;th&gt;$escapetool.xml($services.localization.render(
+                  'adminTools.dashboard.healthcheck.modal.wikiBins.header.wiki'))&lt;/th&gt;
+                &lt;th&gt;$escapetool.xml($services.localization.render(
+                  'adminTools.dashboard.healthcheck.modal.wikiBins.header.page'))&lt;/th&gt;
+                &lt;th&gt;$escapetool.xml($services.localization.render(
+                  'adminTools.dashboard.healthcheck.modal.wikiBins.header.attach'))&lt;/th&gt;
+                &lt;th&gt;$escapetool.xml($services.localization.render(
+                  'adminTools.dashboard.healthcheck.modal.wikiBins.header.total'))&lt;/th&gt;
+              &lt;/tr&gt;
+              #foreach($wikiBin in $wikisRecycleBin)
+                #set ($allDocsRef = $services.model.createDocumentReference($wikiBin.getWikiId(), 'Main', 'AllDocs'))
+                #set ($wikiBinTotal = $wikiBin.getDocumentsCount() + $wikiBin.getAttachmentsCount())
+                &lt;tr&gt;
+                  &lt;td&gt;$wikiBin.getWikiName()&lt;/td&gt;
+                  &lt;td&gt;
+                    &lt;a href="${xwiki.getURL($allDocsRef, 'view', $escapetool.url({'view': 'deletedDocs'}))}"
+                      target="_blank" title="$escapetool.xml($services.localization.render(
+                      'adminTools.dashboard.healthcheck.modal.wikiBins.documents'))"&gt;
+                        $wikiBin.getDocumentsCount()&lt;/a&gt;
+                  &lt;/td&gt;
+                  &lt;td&gt;
+                    &lt;a href="${xwiki.getURL($allDocsRef, 'view', $escapetool.url({'view': 'deletedAttachments'}))}"
+                      target="_blank" title="$escapetool.xml($services.localization.render(
+                      'adminTools.dashboard.healthcheck.modal.wikiBins.attachments'))"&gt;
+                        $wikiBin.getAttachmentsCount()&lt;/a&gt;
+                  &lt;/td&gt;
+                  &lt;td&gt;$wikiBinTotal&lt;/td&gt;
                 &lt;/tr&gt;
-                #foreach($wikiBin in $wikisRecycleBin)
-                  #set ($allDocsRef = $services.model.createDocumentReference($wikiBin.getWikiId(), 'Main', 'AllDocs'))
-                  #set ($wikiBinTotal = $wikiBin.getDocumentsCount() + $wikiBin.getAttachmentsCount())
-                  &lt;tr&gt;
-                    &lt;td&gt;$wikiBin.getWikiName()&lt;/td&gt;
-                    &lt;td&gt;
-                      &lt;a href="${xwiki.getURL($allDocsRef, 'view', $escapetool.url({'view': 'deletedDocs'}))}"
-                        target="_blank" title="$escapetool.xml($services.localization.render(
-                        'adminTools.dashboard.healthcheck.modal.wikiBins.documents'))"&gt;
-                          $wikiBin.getDocumentsCount()&lt;/a&gt;
-                    &lt;/td&gt;
-                    &lt;td&gt;
-                      &lt;a href="${xwiki.getURL($allDocsRef, 'view', $escapetool.url({'view': 'deletedAttachments'}))}"
-                        target="_blank" title="$escapetool.xml($services.localization.render(
-                        'adminTools.dashboard.healthcheck.modal.wikiBins.attachments'))"&gt;
-                          $wikiBin.getAttachmentsCount()&lt;/a&gt;
-                    &lt;/td&gt;
-                    &lt;td&gt;$wikiBinTotal&lt;/td&gt;
-                  &lt;/tr&gt;
-                #end
-              &lt;/table&gt;
-            #else
-              #set($warningMessage = $escapetool.xml($services.localization.render(
-                'adminTools.dashboard.healthcheck.modal.wikiBins.error')))
-              #error($warningMessage)
-            #end
-          &lt;/div&gt;
-          &lt;div class="modal-footer"&gt;
-            &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
-              $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
-          &lt;/div&gt;
+              #end
+            &lt;/table&gt;
+          #else
+            #set($warningMessage = $escapetool.xml($services.localization.render(
+              'adminTools.dashboard.healthcheck.modal.wikiBins.error')))
+            #error($warningMessage)
+          #end
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
         &lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Macros.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Macros.xml
@@ -240,7 +240,7 @@
           &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;
-          {{include reference="AdminTools.Code.WikisSize" /}}
+          {{include reference="AdminTools.WikisSize" /}}
         &lt;/div&gt;
         &lt;div class="modal-footer"&gt;
           &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Translations.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Translations.xml
@@ -130,15 +130,14 @@ adminTools.dashboard.healthcheck.linkLabel=help links
 
 ##Instance usage
 adminTools.dashboard.instanceUsage.description=See the stats related to the usage of the instance.
-adminTools.dashboard.instanceUsage.error=There have been issues while gathering info about the size of the Wikis.
 adminTools.dashboard.instanceUsage.title=Instance usage
 adminTools.dashboard.instanceUsage.total.extensions=There are {0} extensions installed.
 adminTools.dashboard.instanceUsage.total.users=There are a total of {0} users registered in this XWiki instance.
 adminTools.dashboard.instanceUsage.wiki.attachments=Number of attachments: {0} ({1})
 adminTools.dashboard.instanceUsage.wiki.documents=Number of documents: {0}
-adminTools.dashboard.instanceUsage.wiki.name=Size info for Wiki {0}
+adminTools.dashboard.instanceUsage.wiki.name=Size info for wiki {0}
 adminTools.dashboard.instanceUsage.wiki.users=Number of users: {0}
-adminTools.dashboard.instanceUsage.wiki.viewAll=View the size of all wikis
+adminTools.dashboard.instanceUsage.wiki.viewAll=View usage info for all wikis
 adminTools.dashboard.instanceUsage.specific=Specific stats
 adminTools.dashboard.instanceUsage.specific.comments=View pages with over {0} comments
 adminTools.dashboard.instanceUsage.specific.comments.hint=View a list with all the pages that have above {0} comments
@@ -207,7 +206,7 @@ adminTools.dashboard.healthcheck.modal.wikiBins.header.total=Total
 adminTools.dashboard.healthcheck.modal.wikiBins.documents=View deleted pages
 adminTools.dashboard.healthcheck.modal.wikiBins.attachments=View deleted attachments
 adminTools.dashboard.instanceUsage.modal.wikiSize.attachmentsCount=Attachments count
-adminTools.dashboard.instanceUsage.modal.wikiSize.attachmentsSize=Attachments size
+adminTools.dashboard.instanceUsage.modal.wikiSize.attachmentsSize=Total attachments size
 adminTools.dashboard.instanceUsage.modal.wikiSize.documentsCount=Documents count
 adminTools.dashboard.instanceUsage.modal.wikiSize.name=Wiki name
 adminTools.dashboard.instanceUsage.modal.wikiSize.title=Wikis size

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Translations.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Translations.xml
@@ -138,6 +138,7 @@ adminTools.dashboard.instanceUsage.wiki.attachments=Number of attachments: {0} (
 adminTools.dashboard.instanceUsage.wiki.documents=Number of documents: {0}
 adminTools.dashboard.instanceUsage.wiki.name=Size info for Wiki {0}
 adminTools.dashboard.instanceUsage.wiki.users=Number of users: {0}
+adminTools.dashboard.instanceUsage.wiki.viewAll=View the size of all wikis
 adminTools.dashboard.instanceUsage.specific=Specific stats
 adminTools.dashboard.instanceUsage.specific.comments=View pages with over {0} comments
 adminTools.dashboard.instanceUsage.specific.comments.hint=View a list with all the pages that have above {0} comments
@@ -204,7 +205,13 @@ adminTools.dashboard.healthcheck.modal.wikiBins.header.page=Deleted pages
 adminTools.dashboard.healthcheck.modal.wikiBins.header.attach=Deleted attachments
 adminTools.dashboard.healthcheck.modal.wikiBins.header.total=Total
 adminTools.dashboard.healthcheck.modal.wikiBins.documents=View deleted pages
-adminTools.dashboard.healthcheck.modal.wikiBins.attachments=View deleted attachments</content>
+adminTools.dashboard.healthcheck.modal.wikiBins.attachments=View deleted attachments
+adminTools.dashboard.instanceUsage.modal.wikiSize.attachmentsCount=Attachments count
+adminTools.dashboard.instanceUsage.modal.wikiSize.attachmentsSize=Attachments size
+adminTools.dashboard.instanceUsage.modal.wikiSize.documentsCount=Documents count
+adminTools.dashboard.instanceUsage.modal.wikiSize.name=Wiki name
+adminTools.dashboard.instanceUsage.modal.wikiSize.title=Wikis size
+adminTools.dashboard.instanceUsage.modal.wikiSize.userCount=User count</content>
   <object>
     <name>AdminTools.Code.Translations</name>
     <number>0</number>

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/WikisSize.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/WikisSize.xml
@@ -1,0 +1,103 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="AdminTools.Code.WikisSize" locale="">
+  <web>AdminTools.Code</web>
+  <name>WikisSize</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>AdminTools.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>Wikis Size</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+#set ($sourceParameters = $escapetool.url({
+    'className': 'AdminTools.Code.WikisSize',
+    'resultPage': 'AdminTools.Code.WikisSizeJSON',
+    'translationPrefix': 'adminTools.dashboard.instanceUsage.modal.wikiSize.'
+  }))
+  #set ($liveDataConfig= {
+    'meta': {
+      'propertyDescriptors': [
+        {'id': 'name', 'displayer': 'html'},
+        {'id': 'userCount', 'displayer': 'number'},
+        {'id': 'documentsCount', 'displayer': 'number', 'filterable': false},
+        {'id': 'attachmentsCount', 'displayer': 'number', 'filterable': false},
+        {'id': 'attachmentsSize', 'displayer': 'html'}
+      ],
+      'entryDescriptor': {
+        'idProperty': 'name'
+      }
+    }
+  })
+
+  {{liveData
+    id='wikisSize'
+    properties="name, userCount, documentsCount, attachmentsCount, attachmentsSize"
+    source='liveTable'
+    sourceParameters="$sourceParameters"
+    sort='name:asc'
+  }}$jsontool.serialize($liveDataConfig){{/liveData}}
+{{/velocity}}</content>
+  <class>
+    <name>AdminTools.Code.WikisSize</name>
+    <customClass/>
+    <customMapping/>
+    <defaultViewSheet/>
+    <defaultEditSheet/>
+    <defaultWeb/>
+    <nameField/>
+    <validationScript/>
+    <attachmentsSize>
+      <cache>0</cache>
+      <customDisplay/>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayType>select</displayType>
+      <freeText>discouraged</freeText>
+      <hint/>
+      <largeStorage>0</largeStorage>
+      <multiSelect>0</multiSelect>
+      <name>attachmentsSize</name>
+      <number>1</number>
+      <picker>0</picker>
+      <prettyName>Attachments Size</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators>|, </separators>
+      <size>1</size>
+      <sort>none</sort>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values>0-1048000=Tiny|1048000-10480000=Small|10480000-104800000=Medium|104800000-x=Large</values>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </attachmentsSize>
+  </class>
+</xwikidoc>

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/WikisSizeJSON.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/WikisSizeJSON.xml
@@ -1,0 +1,92 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="AdminTools.Code.WikisSizeJSON" locale="">
+  <web>AdminTools.Code</web>
+  <name>WikisSizeJSON</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>AdminTools.Code.WikisSize</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>WikisSizeJSON</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+#if ($xcontext.action == 'get')
+  #set ($offset = $numbertool.toNumber($request.offset).intValue())
+  ## The offset sent by the live table starts at 1.
+  #set ($offset = $offset - 1)
+  #if (!$offset || $offset &lt; 0)
+    #set ($offset = 0)
+  #end
+  #set ($limit = $numbertool.toNumber($request.limit).intValue())
+  #if (!$limit)
+    #set ($limit = 15)
+  #end
+  #set ($sort = 'name')
+  #set ($order = 'desc')
+  #if ($request.sort)
+    #set ($sort = $request.sort)
+    #set ($order = $request.dir)
+  #end
+  #set ($filters = {
+    'name' : $request.get('name'),
+    'userCount' : $request.get('userCount'),
+    'documentsCount' : $request.get('documentsCount'),
+    'attachmentsCount' : $request.get('attachmentsCount'),
+    'attachmentsSize' : $request.get('attachmentsSize')
+  })
+  #set ($wikisSize = $services.admintools.getWikisSize($filters, $sort, $order))
+  #if ($offset &lt; $wikisSize.size())
+    #set ($toIndex = $mathtool.min($mathtool.add($offset, $limit), $wikisSize.size()))
+    #set ($resultList = [])
+    #set ($toIndex = $mathtool.sub($toIndex, 1))
+    #foreach ($i in [$offset..$toIndex])
+      #set ($element = $wikisSize.get($i))
+      #set ($discard = $resultList.add($element))
+    #end
+  #end
+  #set ($results = {
+    "totalrows": $wikisSize.size(),
+    "returnedrows": $resultList.size(),
+    "offset": $mathtool.add($offset, 1),
+    "rows": []
+  })
+  #foreach ($currentEntry in $resultList)
+    #set ($discard = $results.rows.add({
+      'name' : $currentEntry.getName(),
+      'userCount' :  $currentEntry.getUserCount(),
+      'documentsCount' : $currentEntry.getDocumentsCount(),
+      'attachmentsCount' : $currentEntry.getAttachmentsCount(),
+      'attachmentsSize' : $currentEntry.getReadableAttachmentSize()
+    }))
+  #end
+  #jsonResponse($results)
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/application-admintools-ui/src/main/resources/AdminTools/WebHome.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/WebHome.xml
@@ -321,7 +321,7 @@
     <property>
       <content>{{velocity}}
 =$services.icon.render('drive') {{translation key='adminTools.dashboard.instanceUsage.title'/}}=
-{{html}}
+{{html clean='false', wiki='true'}}
   $services.admintools.getInstanceSizeSection()
 {{/html}}
 {{/velocity}}</content>
@@ -453,7 +453,7 @@
 .gadget-content {
   background-color: $theme.pageBackgroundColor;
   border-color: $theme.pageContentBackgroundColor;
-  padding: 1rem 1.1rem;
+  padding: 1rem 2rem;
 }
 
 .backend-section, .files-section {
@@ -489,11 +489,6 @@
 
 .health-check-wrapper button {
   margin-top: 2rem;
-}
-
-.wikis-size-info-list {
-  max-height: 20rem;
-  overflow-y: auto;
 }</code>
     </property>
     <property>

--- a/application-admintools-ui/src/main/resources/AdminTools/WikisSize.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/WikisSize.xml
@@ -20,11 +20,11 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.5" reference="AdminTools.Code.WikisSize" locale="">
-  <web>AdminTools.Code</web>
+<xwikidoc version="1.5" reference="AdminTools.WikisSize" locale="">
+  <web>AdminTools</web>
   <name>WikisSize</name>
   <language/>
-  <defaultLanguage/>
+  <defaultLanguage>en</defaultLanguage>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
   <parent>AdminTools.WebHome</parent>
@@ -35,10 +35,10 @@
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
-  <hidden>true</hidden>
+  <hidden>false</hidden>
   <content>{{velocity}}
 #set ($sourceParameters = $escapetool.url({
-    'className': 'AdminTools.Code.WikisSize',
+    'className': 'AdminTools.WikisSize',
     'resultPage': 'AdminTools.Code.WikisSizeJSON',
     'translationPrefix': 'adminTools.dashboard.instanceUsage.modal.wikiSize.'
   }))
@@ -66,7 +66,7 @@
   }}$jsontool.serialize($liveDataConfig){{/liveData}}
 {{/velocity}}</content>
   <class>
-    <name>AdminTools.Code.WikisSize</name>
+    <name>AdminTools.WikisSize</name>
     <customClass/>
     <customMapping/>
     <defaultViewSheet/>


### PR DESCRIPTION
Modified the `Instance usage` dashboard section to display only the data from the current wiki and added a modal to display the live data table with all wikis: 
![image](https://github.com/xwikisas/application-admintools/assets/104432589/698cf7f6-d65e-48db-b7ea-2e257cb60fa8)
![image](https://github.com/xwikisas/application-admintools/assets/104432589/64754642-be89-4078-b560-1be4fdda8e04)
![image](https://github.com/xwikisas/application-admintools/assets/104432589/bd5af7b3-4642-4de2-a7e3-db5f31c4173d)

Created a page for the live data table:
![image](https://github.com/xwikisas/application-admintools/assets/104432589/d87d2805-91f0-48ac-9bcf-bf1baa97ce11)