### PR TITLE
Admin Tools config page remains in Administration after uninstall #99

### DIFF
--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
@@ -334,7 +334,15 @@
       <categoryIcon/>
     </property>
     <property>
-      <codeToExecute/>
+      <codeToExecute>#set ($adminToolsConfigClassName = 'AdminTools.Code.ConfigurationClass')
+#set ($classExists = $xwiki.exists($adminToolsConfigClassName))
+#if (!$classExists)
+  #set($infoMessage = "The configuration options for Admin Tools Pro are unavailable because the application has been uninstalled.&lt;br&gt;To remove Admin Tools Pro from administration configuration, please &lt;a href=$xwiki.getURL('AdminTools.Code.Configuration', 'delete')&gt;&lt;b&gt;delete this page&lt;/b&gt;&lt;/a&gt;. Note that deleting the page will permanently erase any custom configurations made on Admin Tools Pro configuration.")
+
+{{html clean=false}}
+  #info($infoMessage)
+{{/html}}
+#end</codeToExecute>
     </property>
     <property>
       <configurationClass>AdminTools.Code.ConfigurationClass</configurationClass>

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
@@ -335,8 +335,7 @@
     </property>
     <property>
       <codeToExecute>#set ($adminToolsConfigClassName = 'AdminTools.Code.ConfigurationClass')
-#set ($classExists = $xwiki.exists($adminToolsConfigClassName))
-#if (!$classExists)
+#if (!$xwiki.exists($adminToolsConfigClassName))
 {{info}}
 {{html clean="false"}}
   &lt;p&gt;

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
@@ -337,11 +337,18 @@
       <codeToExecute>#set ($adminToolsConfigClassName = 'AdminTools.Code.ConfigurationClass')
 #set ($classExists = $xwiki.exists($adminToolsConfigClassName))
 #if (!$classExists)
-  #set($infoMessage = "The configuration options for Admin Tools Pro are unavailable because the application has been uninstalled.&lt;br&gt;To remove Admin Tools Pro from administration configuration, please &lt;a href=$xwiki.getURL('AdminTools.Code.Configuration', 'delete')&gt;&lt;b&gt;delete this page&lt;/b&gt;&lt;/a&gt;. Note that deleting the page will permanently erase any custom configurations made on Admin Tools Pro configuration.")
-
-{{html clean=false}}
-  #info($infoMessage)
+{{info}}
+{{html clean="false"}}
+  &lt;p&gt;
+    The configuration options for Admin Tools Pro are unavailable because the application has been uninstalled.
+  &lt;/p&gt;
+  &lt;p&gt;To remove Admin Tools Pro from administration configuration, please
+    &lt;a href="${xwiki.getURL('AdminTools.Code.Configuration', 'delete')}"&gt;
+      &lt;b&gt;delete this page&lt;/b&gt;&lt;/a&gt;.&lt;/p&gt;
+  &lt;p&gt;Note that deleting the page will &lt;b&gt;permanently erase&lt;/b&gt; any custom configurations made on
+    Admin Tools Pro configuration.&lt;/p&gt;
 {{/html}}
+{{/info}}
 #end</codeToExecute>
     </property>
     <property>


### PR DESCRIPTION
Added a code to execute inside the Admin Tools Configuration to inform the user of the reason why the Admin Tools is still displayed in administration: 
![Screenshot from 2024-09-12 14-07-13](https://github.com/user-attachments/assets/4d5b2dc7-5ddf-4ed9-9c64-b0ce3f57f818)