### PR TITLE
Show last n lines of log throws HTTP Status 500 – Internal Server Error #135

### DIFF
--- a/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
@@ -239,7 +239,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!admin-tools-cac
     let noLines = modal.find("input[name='noLines']").val();
 
     // If the input is empty, the default value of 1000 will be requested.
-    if (noLines == '') {
+    if (noLines == '' || noLines === undefined) {
       noLines = '1000';
     }
 


### PR DESCRIPTION
Added an additional check to the view last n lines of log JS code.