### PR TITLE
View last n lines of log only returns 1000 lines #149

### DIFF
--- a/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
@@ -236,8 +236,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!admin-tools-cac
     event.preventDefault();
     const modal = $(event.currentTarget).closest('.modal');
     const downloadForm = modal.find('form');
-    let noLines = modal.find("input[name='noLines']").val();
-
+    let noLines = modal.find("#" + $(this).val()).val();
     // If the input is empty, the default value of 1000 will be requested.
     if (noLines == '' || noLines === undefined) {
       noLines = '1000';

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Macros.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Macros.xml
@@ -73,7 +73,7 @@
             &lt;/form&gt;
           &lt;/div&gt;
           &lt;div class="modal-footer"&gt;
-            &lt;button type="button" class="btn btn-primary"&gt;
+            &lt;button type="button" class="btn btn-primary" value="${id}NoLines"&gt;
               $escapetool.xml($services.localization.render('adminTools.dashboard.logs.modal.submit'))&lt;/button&gt;
             &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
               $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;


### PR DESCRIPTION
Added the right input field id to be searched in the `ViewLastNLines` modals.