### PR TITLE
Errors that prevent the progress bar for the Health Check job to be displayed #143

### DIFF
--- a/application-admintools-api/src/main/java/com/xwiki/admintools/jobs/JobResultLevel.java
+++ b/application-admintools-api/src/main/java/com/xwiki/admintools/jobs/JobResultLevel.java
@@ -22,8 +22,8 @@ package com.xwiki.admintools.jobs;
 import org.xwiki.stability.Unstable;
 
 /**
- * Represents the severity level of a job, where "INFO" is for informative results, "WARN" for
- * warnings and "ERROR" for critical issues.
+ * Represents the severity level of a job, where "INFO" is for informative results, "WARN" for warnings, "ERROR"
+ * for severe issues and "FAIL" for job failures.
  *
  * @version $Id$
  * @since 1.0
@@ -31,6 +31,12 @@ import org.xwiki.stability.Unstable;
 @Unstable
 public enum JobResultLevel
 {
+    /**
+     * This is used to mark a job failure.
+     *
+     * @since 1.3
+     */
+    FAIL,
     /**
      * Used to mark a {@link JobResultLevel} as an error.
      */

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/checks/security/LangEncodingHealthCheck.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/checks/security/LangEncodingHealthCheck.java
@@ -47,10 +47,10 @@ public class LangEncodingHealthCheck extends AbstractSecurityHealthCheck
     public JobResult check()
     {
         String langEnc = getSecurityProviderJSON().get("LANG");
-        if (langEnc == null) {
-            logger.warn("Language encoding could not be detected!");
+        if (langEnc == null || !langEnc.contains(".")) {
+            logger.info("Language encoding could not be detected.");
             return new JobResult("adminTools.dashboard.healthcheck.security.system.lang.notFound",
-                JobResultLevel.WARN);
+                JobResultLevel.INFO);
         }
         boolean isSafeLangEnc = isSafeEncoding(langEnc.split("\\.")[1], "System language");
         if (!isSafeLangEnc) {

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/checks/security/LangEncodingHealthCheck.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/checks/security/LangEncodingHealthCheck.java
@@ -47,6 +47,8 @@ public class LangEncodingHealthCheck extends AbstractSecurityHealthCheck
     public JobResult check()
     {
         String langEnc = getSecurityProviderJSON().get("LANG");
+        // Check if the lang result contains the encoding part separated by ".", as on Windows machines it does not
+        // include the encoding and the regex bellow might break the regex.
         if (langEnc == null || !langEnc.contains(".")) {
             logger.info("Language encoding could not be detected.");
             return new JobResult("adminTools.dashboard.healthcheck.security.system.lang.notFound",

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/job/HealthCheckJob.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/job/HealthCheckJob.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.job.AbstractJob;
 import org.xwiki.job.GroupedJob;
@@ -33,9 +34,10 @@ import org.xwiki.job.JobGroupPath;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xwiki.admintools.health.HealthCheck;
-import com.xwiki.admintools.jobs.JobResult;
 import com.xwiki.admintools.jobs.HealthCheckJobRequest;
 import com.xwiki.admintools.jobs.HealthCheckJobStatus;
+import com.xwiki.admintools.jobs.JobResult;
+import com.xwiki.admintools.jobs.JobResultLevel;
 
 /**
  * The Admin Tools health check job.
@@ -99,6 +101,12 @@ public class HealthCheckJob extends AbstractJob<HealthCheckJobRequest, HealthChe
                     Thread.yield();
                 }
             }
+        } catch (Exception e) {
+            logger.error("An error occurred while running the health check. Root cause is: [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
+            status.getJobResults()
+                .add(new JobResult("adminTools.dashboard.healthcheck.execution.error", JobResultLevel.FAIL));
+            throw new RuntimeException(e);
         } finally {
             this.progressManager.popLevelProgress(this);
         }

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/job/HealthCheckJob.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/job/HealthCheckJob.java
@@ -102,8 +102,7 @@ public class HealthCheckJob extends AbstractJob<HealthCheckJobRequest, HealthChe
                 }
             }
         } catch (Exception e) {
-            logger.error("An error occurred while running the health check. Root cause is: [{}]",
-                ExceptionUtils.getRootCauseMessage(e));
+            logger.error("An error occurred while running the health check.", e);
             status.getJobResults()
                 .add(new JobResult("adminTools.dashboard.healthcheck.execution.error", JobResultLevel.FAIL));
             throw new RuntimeException(e);

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/health/checks/security/LangEncodingHealthCheckTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/health/checks/security/LangEncodingHealthCheckTest.java
@@ -49,7 +49,7 @@ class LangEncodingHealthCheckTest
     private DataProvider dataProvider;
 
     @RegisterExtension
-    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
 
     @BeforeEach
     void beforeEach() throws Exception
@@ -75,7 +75,7 @@ class LangEncodingHealthCheckTest
             langEncodingHealthCheck.check().getMessage());
         assertEquals("Failed to generate the instance security data. Root cause is: [Exception: error while "
             + "generating the json]", logCapture.getMessage(0));
-        assertEquals("Language encoding could not be detected!", logCapture.getMessage(1));
+        assertEquals("Language encoding could not be detected.", logCapture.getMessage(1));
     }
 
     @Test

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
@@ -199,7 +199,6 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!admin-tools-cac
 
   $(document).ready(function() {
     removeBrokenTOCHeaders();
-
     if ($('#healthCheck').length) {
       initialiseJobJS();
       let jobState = $('.health-check-job-state').attr('data-job-state');
@@ -218,6 +217,10 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!admin-tools-cac
     runHealthCheckJob();
     reinitialiseHealthCheckResources();
     $('#healthCheck .job-status').show();
+  });
+
+  $(document).on('click', '#healthCheck .log-item-error', function(event) {
+    $(this).children('.error-logs').toggle();
   });
 
   $(document).on('click', '#downloadFilesModal .btn-primary', function(event) {

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/JobCommonMacros.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/JobCommonMacros.xml
@@ -37,11 +37,18 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity output='false'}}
+#macro (getResultLevel $result)
+  #set ($resultLevel = 'error')
+  #if ($result.getLevel().name() != 'FAIL')
+    #set ($resultLevel = $result.getLevel().name().toLowerCase())
+  #end
+#end
 #macro (getCustomJobStatusJSON $status $json)
   #set ($results = [])
   #foreach ($result in $status.getJobResults())
+    #getResultLevel($result)
     #set ($discard = $results.add({
-      'level': $result.getLevel().name().toLowerCase(),
+      'level': $resultLevel,
       'renderedMessage': "#printResult($result)"
     }))
   #end
@@ -88,7 +95,9 @@
     $escapetool.xml($services.localization.render($jobResult.getMessage(), $jobResult.getParameters()))
   &lt;/div&gt;
   #if ($jobResult.getLevel().name() == 'FAIL')
-    #printThrowable($status.error)
+    &lt;div class='error-logs' style="cursor: pointer;"&gt;
+      $status.error.getStackTrace()
+    &lt;/div&gt;
   #end
 #end
 #macro (printJobResults $status)
@@ -98,10 +107,7 @@
   #set($jobResults = $status.getJobResults())
   &lt;ul class="log"&gt;
   #foreach ($jobResult in $jobResults)
-    #set ($resultLevel = 'error')
-    #if ($jobResult.getLevel().name() != 'CRITICAL')
-      #set ($resultLevel = $jobResult.getLevel().name().toLowerCase())
-    #end
+    #getResultLevel($jobResult)
     ## Display the last result item as loading if the associated task is not finished.
     &lt;li class="log-item log-item-${resultLevel}#if ($loading &amp;&amp; !$foreach.hasNext) log-item-loading#end"&gt;
       #printResult($jobResult)

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/JobCommonMacros.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/JobCommonMacros.xml
@@ -95,6 +95,7 @@
     $escapetool.xml($services.localization.render($jobResult.getMessage(), $jobResult.getParameters()))
   &lt;/div&gt;
   #if ($jobResult.getLevel().name() == 'FAIL')
+    ## We add the error stack trace in a div to be able to toggle it in the health check logs.
     &lt;div class='error-logs' style="cursor: pointer;"&gt;
       $status.error.getStackTrace()
     &lt;/div&gt;

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/JobCommonMacros.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/JobCommonMacros.xml
@@ -87,6 +87,9 @@
   &lt;div&gt;
     $escapetool.xml($services.localization.render($jobResult.getMessage(), $jobResult.getParameters()))
   &lt;/div&gt;
+  #if ($jobResult.getLevel().name() == 'FAIL')
+    #printThrowable($status.error)
+  #end
 #end
 #macro (printJobResults $status)
   #if ($status.state != 'FINISHED')
@@ -95,7 +98,10 @@
   #set($jobResults = $status.getJobResults())
   &lt;ul class="log"&gt;
   #foreach ($jobResult in $jobResults)
-    #set ($resultLevel = $jobResult.getLevel().name().toLowerCase())
+    #set ($resultLevel = 'error')
+    #if ($jobResult.getLevel().name() != 'CRITICAL')
+      #set ($resultLevel = $jobResult.getLevel().name().toLowerCase())
+    #end
     ## Display the last result item as loading if the associated task is not finished.
     &lt;li class="log-item log-item-${resultLevel}#if ($loading &amp;&amp; !$foreach.hasNext) log-item-loading#end"&gt;
       #printResult($jobResult)

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Translations.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Translations.xml
@@ -111,7 +111,7 @@ adminTools.dashboard.healthcheck.security.system.file.info=System file encoding 
 adminTools.dashboard.healthcheck.security.system.file.notFound=File encoding could not be detected!
 adminTools.dashboard.healthcheck.security.system.lang.warn=System language encoding should be set to UTF-8! Currently using {0}.
 adminTools.dashboard.healthcheck.security.system.lang.info=System language encoding is set to UTF-8.
-adminTools.dashboard.healthcheck.security.system.lang.notFound=Language encoding could not be detected!
+adminTools.dashboard.healthcheck.security.system.lang.notFound=Language encoding could not be determined.
 adminTools.dashboard.healthcheck.security.system.recommendation=System encoding should be set to UTF-8! Please consult the help links page to get further instructions of how to configure the system encoding.
 adminTools.dashboard.healthcheck.security.xwiki.info=XWiki encoding OK.
 adminTools.dashboard.healthcheck.security.xwiki.active.warn=XWiki active encoding should be set to UTF-8! Currently using {0}.
@@ -128,6 +128,7 @@ adminTools.job.notFound=Health check job status not found
 adminTools.dashboard.healthcheck.message.success=No issue found!
 adminTools.dashboard.healthcheck.message.warning=Some issues have been found, for more details please see the results below.
 adminTools.dashboard.healthcheck.message.error=Critical issues were found, please consult the results below!
+adminTools.dashboard.healthcheck.execution.error=An error occurred while running the health check.
 adminTools.dashboard.healthcheck.operations=Instance operations
 adminTools.dashboard.healthcheck.linkLabel=help links
 


### PR DESCRIPTION
Added a new "FAIL" level to `JobResultLevel` to indicate job failures, added a check to the lang health check to make sure that the string contains a "." before applying the regex and improved job error messages and handling.

If the health check job fails, I added a new error message: `An error occurred while running the health check`:
<img width="1232" height="1424" alt="image" src="https://github.com/user-attachments/assets/5509d4d6-f2e9-465d-8062-7350c0ba776c" />

The message can be clicked to be expanded to display the error stack trace:
<img width="1228" height="1070" alt="image" src="https://github.com/user-attachments/assets/038647dc-f472-40aa-8414-7ca1c7ef294e" />

The rest of the messages cannot be expanded (as before), the new fail message being the only one which contains details.
