### PR TITLE
Upgrade XWiki Parent to 15.10 #165

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Integration of administration tools for managing a running XWiki instance.
 * Project Lead: [Sorin Chiuchiu](https://github.com/ChiuchiuSorin)
 * Communication: [Mailing List](http://dev.xwiki.org/xwiki/bin/view/Community/MailingLists>), [IRC]( http://dev.xwiki.org/xwiki/bin/view/Community/IRC)
 * [Development Practices](http://dev.xwiki.org)
-* Minimal XWiki version supported: XWiki 14.10
+* Minimal XWiki version supported: XWiki 15.10
 * License: LGPL 2.1+
 * Translations: N/A
 * Sonar Dashboard: N/A

--- a/application-admintools-default/pom.xml
+++ b/application-admintools-default/pom.xml
@@ -31,7 +31,7 @@
   <name>Admin Tools Application (Pro) - Default</name>
   <description>Admin Tools Application (Pro) - Default</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.76</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.79</xwiki.jacoco.instructionRatio>
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
   </properties>
   <dependencies>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.github.oshi</groupId>
       <artifactId>oshi-core</artifactId>
-      <version>5.8.0</version>
+      <version>6.4.8</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -94,7 +94,14 @@
     <dependency>
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>application-limits-api</artifactId>
-      <version>2.1.3</version>
+      <version>${limits.application.version}</version>
+      <!-- We exclude dependency as it no longer exists, failing the build. -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.xwiki.platform</groupId>
+          <artifactId>xwiki-platform-model</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.groovy</groupId>

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/cache/CacheManager.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/cache/CacheManager.java
@@ -41,7 +41,7 @@ import groovy.jmx.GroovyMBean;
  * Manager class that handles JMX managed cache operations.
  *
  * @version $Id$
- * @since 1.3
+ * @since 1.4
  */
 @Component(roles = CacheManager.class)
 @Singleton

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/cache/GroovyMBeanUtil.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/cache/GroovyMBeanUtil.java
@@ -35,7 +35,7 @@ import groovy.jmx.GroovyMBean;
  * Utility class used to access JMX MBeans.
  *
  * @version $Id$
- * @since 1.3
+ * @since 1.4
  */
 @Component(roles = GroovyMBeanUtil.class)
 @Singleton

--- a/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/checks/performance/CPUHealthCheck.java
+++ b/application-admintools-default/src/main/java/com/xwiki/admintools/internal/health/checks/performance/CPUHealthCheck.java
@@ -59,9 +59,9 @@ public class CPUHealthCheck implements HealthCheck
         HardwareAbstractionLayer hardware = systemInfo.getHardware();
         CentralProcessor processor = hardware.getProcessor();
         int cpuCores = processor.getPhysicalProcessorCount();
-        int maxFreq = (int) (processor.getMaxFreq() / (1024 * 1024));
+        int maxFreq = (int) (processor.getMaxFreq() / (1000 * 1000));
 
-        if (cpuCores > 2 && maxFreq > 2048) {
+        if (cpuCores > 2 && maxFreq > 2000) {
             return new JobResult("adminTools.dashboard.healthcheck.performance.cpu.info",
                 JobResultLevel.INFO);
         }

--- a/application-admintools-default/src/test/java/com/xwiki/admintools/internal/security/EntityRightsProviderTest.java
+++ b/application-admintools-default/src/test/java/com/xwiki/admintools/internal/security/EntityRightsProviderTest.java
@@ -31,6 +31,7 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
@@ -41,6 +42,8 @@ import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryManager;
 import org.xwiki.query.SecureQuery;
 import org.xwiki.search.solr.SolrUtils;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -91,8 +94,8 @@ class EntityRightsProviderTest
     DocumentReference docRef3 =
         new DocumentReference(new LocalDocumentReference("docSpace3", "docTitle3"), new WikiReference("xwiki"));
 
-    DocumentReference docRef4 = new DocumentReference(new LocalDocumentReference("docSpace4", "docTitle4"),
-        new WikiReference("xwiki"));
+    DocumentReference docRef4 =
+        new DocumentReference(new LocalDocumentReference("docSpace4", "docTitle4"), new WikiReference("xwiki"));
 
     DocumentReference docRefGlobal =
         new DocumentReference(new LocalDocumentReference("XWiki", "XWikiPreferences"), new WikiReference("xwiki"));
@@ -198,6 +201,9 @@ class EntityRightsProviderTest
 
     @Mock
     private BaseObject obj6;
+
+    @RegisterExtension
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.ERROR);
 
     @BeforeEach
     void setUp() throws QueryException, XWikiException
@@ -321,8 +327,7 @@ class EntityRightsProviderTest
     {
         Map<String, String> filters = Map.of("type", "Global");
 
-        List<RightsResult> rightsResults =
-            entityRightsProvider.getEntityRights(filters, "level", "desc", "groups");
+        List<RightsResult> rightsResults = entityRightsProvider.getEntityRights(filters, "level", "desc", "groups");
         assertEquals(3, rightsResults.size());
         assertEquals("stringClass6", rightsResults.get(0).getLevel());
         assertEquals("stringClass5", rightsResults.get(1).getLevel());
@@ -338,5 +343,8 @@ class EntityRightsProviderTest
             () -> entityRightsProvider.getEntityRights(filters, "type", "desc", "groups"));
 
         assertEquals("java.lang.RuntimeException: Query error", exception.getMessage());
+        assertEquals(
+            "There was an error while processing the rights for entity [groups]: [RuntimeException: Query error]",
+            logCapture.getMessage(0));
     }
 }

--- a/application-admintools-ui/pom.xml
+++ b/application-admintools-ui/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>com.xwiki.commons</groupId>
       <artifactId>xwiki-pro-commons-pickers-ui</artifactId>
-      <version>1.3.0</version>
+      <version>${pro.commons.pickers}</version>
       <type>xar</type>
     </dependency>
   </dependencies>

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/AdminToolsJS.xml
@@ -198,7 +198,6 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!admin-tools-cac
   };
 
   $(document).ready(function() {
-    removeBrokenTOCHeaders();
     if ($('#healthCheck').length) {
       initialiseJobJS();
       let jobState = $('.health-check-job-state').attr('data-job-state');
@@ -259,29 +258,6 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!admin-tools-cac
       $('#downloadFilesModal .download-logs-date-fields').hide();
     }
   });
-
-  // Remove broken dashboard gadget titles, since in some cases these will be either empty, with the wrong title or
-  // will have no ID set, which will make the link unusable. This method should be updated after upgrading to a
-  // XWiki parent that includes fixes for XWIKI-20600: Gadget headings don't have an ID set, or XRENDERING-707: The toc
-  // macro use the name of the page for empty heading entries. In older versions of the TOC macro, when the heading
-  // is empty, it will automatically generate a text with the name of the page stored in
-  // 'span.wikigeneratedlinkcontent'. We remove the text if it has children, or the entire heading otherwise, as
-  // after the fix of XRENDERING-707, the 'span' is no longer used. We do not however remove those headings that have an
-  // empty ID, but a valid text, since this can happen only when users add their own content to the dashboard and we
-  // don't want to alter the macro behavior or fixes from recent versions.
-  const removeBrokenTOCHeaders = function() {
-    var headings = $('.wikitoc').find('a');
-    for (let element of headings) {
-      if ($(element).children("span.wikigeneratedlinkcontent").length || $.trim($(element).text()) === "") {
-        let parent = element.parentElement.parentElement;
-        if($(parent).children('ul').length){
-          $(element).remove();
-        } else {
-          $(parent).remove();
-        }
-      }
-    }
-  }
 
   $(document).on('click', '#confirmCacheFlushModal .btn-primary', function(event) {
     event.preventDefault();
@@ -402,7 +378,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-job-runner', 'xwiki-l10n!admin-tools-cac
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/ApplicationsPanelEntry.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/ApplicationsPanelEntry.xml
@@ -77,7 +77,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/Code/Configuration.xml
@@ -58,7 +58,7 @@
         <editor>PureText</editor>
         <hint/>
         <name>excludedLines</name>
-        <number>2</number>
+        <number>3</number>
         <picker>1</picker>
         <prettyName>excludedLines</prettyName>
         <restricted>0</restricted>
@@ -88,7 +88,7 @@
         <disabled>0</disabled>
         <hint/>
         <name>spamSize</name>
-        <number>3</number>
+        <number>4</number>
         <numberType>long</numberType>
         <prettyName>spamSize</prettyName>
         <size>30</size>
@@ -97,6 +97,20 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
       </spamSize>
+      <xwikiInstallLocation>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>xwikiInstallLocation</name>
+        <number>2</number>
+        <picker>1</picker>
+        <prettyName>xwikiInstallLocation</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </xwikiInstallLocation>
     </class>
     <property>
       <excludedLines/>
@@ -106,6 +120,9 @@
     </property>
     <property>
       <spamSize>50</spamSize>
+    </property>
+    <property>
+      <xwikiInstallLocation/>
     </property>
   </object>
   <object>

--- a/application-admintools-ui/src/main/resources/AdminTools/WebHome.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/WebHome.xml
@@ -43,7 +43,7 @@
     {{box cssClass="admin-tools-header-section"}}
       {{container layoutStyle="columns" justify="yes"}}
         (((
-        {{toc scope=page /}}
+        {{toc scope=page start="2" /}}
         )))
       {{/container}}
     {{/box}}
@@ -112,7 +112,7 @@
     </class>
     <property>
       <content>{{velocity}}
-=$services.icon.render('world') {{translation key='adminTools.dashboard.backend.title'/}}=
+==$services.icon.render('world') {{translation key='adminTools.dashboard.backend.title'/}}==
 {{html clean='false'}}
   $services.admintools.getConfigurationData('configuration')
 {{/html}}
@@ -180,7 +180,7 @@
     </class>
     <property>
       <content>{{velocity}}
-=$services.icon.render('download') {{translation key='adminTools.dashboard.download.title'/}}=
+==$services.icon.render('download') {{translation key='adminTools.dashboard.download.title'/}}==
 {{html clean='false'}}
   $services.admintools.getFilesSection()
 {{/html}}
@@ -249,10 +249,10 @@
     <property>
       <content>{{template name="job_macros.vm"/}}
 
-{{include reference="AdminTools.Code.HealthCheckMacros" /}}
+{{include reference="AdminTools.Code.HealthCheckMacros"/}}
 
 {{velocity}}
-=$services.icon.render('bug') {{translation key='adminTools.dashboard.healthcheck.title'/}}=
+==$services.icon.render('bug') {{translation key='adminTools.dashboard.healthcheck.title'/}}==
   {{html clean='false' wiki='true'}}
     #healthCheckUI()
   {{/html}}
@@ -320,7 +320,7 @@
     </class>
     <property>
       <content>{{velocity}}
-=$services.icon.render('drive') {{translation key='adminTools.dashboard.instanceUsage.title'/}}=
+==$services.icon.render('drive') {{translation key='adminTools.dashboard.instanceUsage.title'/}}==
 {{html clean='false', wiki='true'}}
   $services.admintools.getInstanceSizeSection()
 {{/html}}
@@ -388,7 +388,7 @@
     </class>
     <property>
       <content>{{velocity}}
-=$services.icon.render('key') {{translation key='adminTools.dashboard.security.title'/}}=
+==$services.icon.render('key') {{translation key='adminTools.dashboard.security.title'/}}==
 {{html clean='false', wiki='true'}}
   $services.admintools.getConfigurationData('security')
 {{/html}}
@@ -457,7 +457,7 @@
     <property>
       <content>{{velocity}}
 #if (!$services.limits.customLimits.isEmpty())
-  =$services.icon.render('cloud') {{translation key='adminTools.dashboard.cloud.title'/}}=
+  ==$services.icon.render('cloud') {{translation key='adminTools.dashboard.cloud.title'/}}==
   {{async async="true" context="user"}}
   {{html clean='false'}}
     #cloudSectionUI()
@@ -688,7 +688,7 @@
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -830,7 +830,7 @@ path=$services.webjars.url('com.xwiki.admintools:application-admintools-webjar',
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>

--- a/application-admintools-ui/src/main/resources/AdminTools/WebPreferences.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/WebPreferences.xml
@@ -304,7 +304,7 @@
   #set ($value = $xwiki.getDefaultDocumentSyntax())
 #end
 &lt;select name="${object.getxWikiClass().name}_${object.number}_${name}" id="${object.getxWikiClass().name}_${object.number}_${name}"&gt;
-#set ($configuredSyntaxes = $services.rendering.getConfiguredSyntaxes())
+#set ($configuredSyntaxes = $collectiontool.sort($services.rendering.getConfiguredSyntaxes()))
 #foreach($syntax in $configuredSyntaxes)
   &lt;option value="$syntax.toIdString()"#if($syntax.toIdString().equalsIgnoreCase($value)) selected="selected"#end&gt;$syntax.toString()&lt;/option&gt;
 #end
@@ -1358,7 +1358,19 @@
       <accessibility/>
     </property>
     <property>
+      <admin_email/>
+    </property>
+    <property>
       <colorTheme/>
+    </property>
+    <property>
+      <comment_anonymous/>
+    </property>
+    <property>
+      <comment_registered/>
+    </property>
+    <property>
+      <confirmation_email_content/>
     </property>
     <property>
       <core.defaultDocumentSyntax/>
@@ -1367,10 +1379,25 @@
       <dateformat/>
     </property>
     <property>
+      <default_language/>
+    </property>
+    <property>
+      <documentBundles/>
+    </property>
+    <property>
+      <edit_anonymous/>
+    </property>
+    <property>
+      <edit_registered/>
+    </property>
+    <property>
       <editcomment/>
     </property>
     <property>
       <editcomment_mandatory/>
+    </property>
+    <property>
+      <editor/>
     </property>
     <property>
       <guest_comment_requires_captcha/>
@@ -1379,7 +1406,13 @@
       <iconTheme/>
     </property>
     <property>
+      <invitation_email_content/>
+    </property>
+    <property>
       <javamail_extra_props/>
+    </property>
+    <property>
+      <languages/>
     </property>
     <property>
       <ldap/>
@@ -1439,7 +1472,13 @@
       <ldap_validate_password/>
     </property>
     <property>
+      <leftPanels/>
+    </property>
+    <property>
       <leftPanelsWidth/>
+    </property>
+    <property>
+      <meta/>
     </property>
     <property>
       <minoredit/>
@@ -1452,6 +1491,15 @@
     </property>
     <property>
       <plugins/>
+    </property>
+    <property>
+      <registration_anonymous/>
+    </property>
+    <property>
+      <registration_registered/>
+    </property>
+    <property>
+      <rightPanels/>
     </property>
     <property>
       <rightPanelsWidth/>
@@ -1472,7 +1520,13 @@
       <showinformation/>
     </property>
     <property>
+      <skin/>
+    </property>
+    <property>
       <smtp_port/>
+    </property>
+    <property>
+      <smtp_server/>
     </property>
     <property>
       <smtp_server_password/>
@@ -1481,13 +1535,31 @@
       <smtp_server_username/>
     </property>
     <property>
+      <stylesheet/>
+    </property>
+    <property>
+      <stylesheets/>
+    </property>
+    <property>
       <tags/>
     </property>
     <property>
       <timezone/>
     </property>
     <property>
+      <title/>
+    </property>
+    <property>
       <upload_maxsize/>
+    </property>
+    <property>
+      <validation_email_content/>
+    </property>
+    <property>
+      <version/>
+    </property>
+    <property>
+      <webcopyright/>
     </property>
     <property>
       <xwiki.title.mandatory/>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.xwiki.parent</groupId>
     <artifactId>xwikisas-parent-platform</artifactId>
-    <version>14.10-1</version>
+    <version>15.10</version>
   </parent>
   <groupId>com.xwiki.admintools</groupId>
   <artifactId>application-admintools</artifactId>
@@ -36,7 +36,9 @@
     Use it to manage your XWiki installation. Easily generate configuration reports. Perform sanity checks and show
     logs history.</description>
   <properties>
-    <licensing.version>1.31.1</licensing.version>
+    <licensing.version>1.32</licensing.version>
+    <limits.application.version>2.1.3</limits.application.version>
+    <pro.commons.pickers>1.3.0</pro.commons.pickers>
   </properties>
   <issueManagement>
     <system>GitHub</system>


### PR DESCRIPTION
* upgraded xwiki parent to 15.10
* tested features and exported documents from a 15.10 instance
* moved dependencies versions to parent pom properties
* removed toc cleanup and modified toc to render starting with level 2 headers
* modified headers to H2
* removed leftover code from AdminToolsJS
* updated readme
* updated licensor version
* updated OSHI version to the latest supported one
* added log capture on test
* excluded xwiki-platform-model from application-limits-api to avoid build failure
* fixed CPU frequency check to use the right size