### PR TITLE
Table of content displays empty lines #179

### DIFF
--- a/application-admintools-ui/src/main/resources/AdminTools/WebHome.xml
+++ b/application-admintools-ui/src/main/resources/AdminTools/WebHome.xml
@@ -43,7 +43,7 @@
     {{box cssClass="admin-tools-header-section"}}
       {{container layoutStyle="columns" justify="yes"}}
         (((
-        {{toc scope=page start="2" /}}
+        {{toc scope=page start="3" /}}
         )))
       {{/container}}
     {{/box}}
@@ -112,7 +112,7 @@
     </class>
     <property>
       <content>{{velocity}}
-==$services.icon.render('world') {{translation key='adminTools.dashboard.backend.title'/}}==
+===$services.icon.render('world'){{translation key='adminTools.dashboard.backend.title'/}}===
 {{html clean='false'}}
   $services.admintools.getConfigurationData('configuration')
 {{/html}}
@@ -180,7 +180,7 @@
     </class>
     <property>
       <content>{{velocity}}
-==$services.icon.render('download') {{translation key='adminTools.dashboard.download.title'/}}==
+===$services.icon.render('download'){{translation key='adminTools.dashboard.download.title'/}}===
 {{html clean='false'}}
   $services.admintools.getFilesSection()
 {{/html}}
@@ -252,7 +252,7 @@
 {{include reference="AdminTools.Code.HealthCheckMacros"/}}
 
 {{velocity}}
-==$services.icon.render('bug') {{translation key='adminTools.dashboard.healthcheck.title'/}}==
+===$services.icon.render('bug'){{translation key='adminTools.dashboard.healthcheck.title'/}}===
   {{html clean='false' wiki='true'}}
     #healthCheckUI()
   {{/html}}
@@ -320,7 +320,7 @@
     </class>
     <property>
       <content>{{velocity}}
-==$services.icon.render('drive') {{translation key='adminTools.dashboard.instanceUsage.title'/}}==
+===$services.icon.render('drive'){{translation key='adminTools.dashboard.instanceUsage.title'/}}===
 {{html clean='false', wiki='true'}}
   $services.admintools.getInstanceSizeSection()
 {{/html}}
@@ -388,7 +388,7 @@
     </class>
     <property>
       <content>{{velocity}}
-==$services.icon.render('key') {{translation key='adminTools.dashboard.security.title'/}}==
+===$services.icon.render('key'){{translation key='adminTools.dashboard.security.title'/}}===
 {{html clean='false', wiki='true'}}
   $services.admintools.getConfigurationData('security')
 {{/html}}
@@ -457,7 +457,7 @@
     <property>
       <content>{{velocity}}
 #if (!$services.limits.customLimits.isEmpty())
-  ==$services.icon.render('cloud') {{translation key='adminTools.dashboard.cloud.title'/}}==
+  ===$services.icon.render('cloud'){{translation key='adminTools.dashboard.cloud.title'/}}===
   {{async async="true" context="user"}}
   {{html clean='false'}}
     #cloudSectionUI()


### PR DESCRIPTION
* Replaced H2 with H3 headers and removed space between header and images.

Old look:
<img width="3286" height="2556" alt="image" src="https://github.com/user-attachments/assets/b6e3defa-23c7-4be7-91a2-c012f26aad9d" />


New look:
<img width="2342" height="1770" alt="image" src="https://github.com/user-attachments/assets/b5e05174-332a-4a04-8d5e-6a9d7187cc1b" />
